### PR TITLE
refactor: load configuration from env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# PostgreSQL configuration
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=trainium
+POSTGRES_PORT=5434
+
+# Service ports
+POSTGREST_PORT=3000
+FRONTEND_PORT=5173
+PYTHON_SERVICE_PORT=8000
+
+# Application settings
+ENVIRONMENT=development
+LOG_LEVEL=INFO
+DEBUG=false
+
+# API keys
+GEMINI_API_KEY=your_gemini_api_key
+
+# Database connection string
+DATABASE_URL=postgresql://postgres:postgres@db:5432/trainium
+POSTGREST_URL=http://postgrest:3000

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ MANIFEST
 # Ignore environment and sensitive config files
 .env
 .env.*
+!.env.example
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -20,19 +20,17 @@ npm install
 npm run dev
 ```
 
-Set `GEMINI_API_KEY` in a `.env` file before starting.
+Copy `.env.example` to `.env` and update the values (like `GEMINI_API_KEY` and database credentials) before starting.
 
 ## Run python-service
 
 ```bash
 cd python-service
 pip install -r requirements.txt
-export GEMINI_API_KEY=your_api_key
-export POSTGREST_URL=http://localhost:3000
 uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ```
 
-API docs are available at `http://localhost:8000/docs`.
+The service reads configuration from the `.env` file. API docs are available at `http://localhost:8000/docs`.
 
 ## Docker Compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       DEBUG: ${DEBUG:-false}
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       POSTGREST_URL: http://postgrest:3000
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
     volumes:
       # Mount the python service code for development
       - ./python-service:/app

--- a/python-service/README.md
+++ b/python-service/README.md
@@ -23,11 +23,8 @@ FastAPI-based microservice that provides AI capabilities for the Trainium Job Ce
    pip install -r requirements.txt
    ```
 
-2. **Set Environment Variables**:
-   ```bash
-   export GEMINI_API_KEY=your_api_key_here
-   export POSTGREST_URL=http://localhost:3000
-   ```
+2. **Configure Environment**:
+   Copy `.env.example` from the project root to `.env` and adjust the values as needed.
 
 3. **Run the Service**:
    ```bash

--- a/python-service/app/core/config.py
+++ b/python-service/app/core/config.py
@@ -1,15 +1,15 @@
-"""
-Core application configuration and settings.
-"""
+"""Core application configuration and settings."""
 from typing import Optional
 import os
 from loguru import logger
+from dotenv import load_dotenv
 
 
 class Settings:
     """Application settings and configuration."""
     
     def __init__(self):
+        load_dotenv()
         # API Configuration
         self.app_name: str = "Trainium Python AI Service"
         self.app_version: str = "1.0.0"
@@ -30,7 +30,9 @@ class Settings:
         self.postgrest_url: str = os.getenv("POSTGREST_URL", "http://postgrest:3000")
         
         # Database Configuration for direct access
-        self.database_url: str = os.getenv("DATABASE_URL", "postgresql://trainium_user:password@localhost:5434/trainium")
+        self.database_url: str = os.getenv("DATABASE_URL", "")
+        if not self.database_url:
+            raise ValueError("DATABASE_URL is not set")
         
         # Redis Configuration for queue system
         self.redis_url: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -5,6 +5,8 @@ python-multipart==0.0.17
 loguru==0.7.3
 httpx==0.28.1
 python-json-logger==2.0.7
+# Load environment variables from .env files
+python-dotenv==1.0.1
 # Future Gemini integration dependencies
 google-generativeai==0.8.3
 # JobSpy for job scraping integration


### PR DESCRIPTION
## Summary
- load environment variables via `dotenv` in python service and require `DATABASE_URL`
- document environment setup and add `.env.example`
- expose database URL to python service in docker compose

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b5e6eade588330b5514975d49b48c6