### PR TITLE
docs: add Redis worker and scheduler instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 
 The service reads configuration from the `.env` file. API docs are available at `http://localhost:8000/docs`.
 
+### Redis, Worker, and Scheduler
+
+The queue system relies on a running Redis instance plus background worker and scheduler processes.
+
+**Manual start:**
+
+```bash
+# Start Redis
+redis-server
+
+# In another terminal
+cd python-service
+python worker.py        # start job worker
+python scheduler_daemon.py  # start scheduler
+```
+
+**Docker:**
+
+```bash
+docker-compose up redis worker scheduler
+```
+
 ## Docker Compose
 
 Run the full stack with Docker:

--- a/python-service/README.md
+++ b/python-service/README.md
@@ -26,12 +26,19 @@ FastAPI-based microservice that provides AI capabilities for the Trainium Job Ce
 2. **Configure Environment**:
    Copy `.env.example` from the project root to `.env` and adjust the values as needed.
 
-3. **Run the Service**:
+3. **Start Redis, Worker, and Scheduler**:
+   ```bash
+   redis-server
+   python worker.py            # job worker
+   python scheduler_daemon.py  # periodic scheduler
+   ```
+
+4. **Run the Service**:
    ```bash
    uvicorn main:app --reload --host 0.0.0.0 --port 8000
    ```
 
-4. **View API Documentation**:
+5. **View API Documentation**:
    - Swagger UI: http://localhost:8000/docs
    - ReDoc: http://localhost:8000/redoc
 
@@ -45,6 +52,12 @@ docker-compose up --build
 ```
 
 The Python service will be available at http://localhost:8000
+
+To run just the queue components:
+
+```bash
+docker-compose up redis worker scheduler
+```
 
 ## API Endpoints
 


### PR DESCRIPTION
## Summary
- document Redis, worker, and scheduler requirements
- add manual and Docker startup examples for background components

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b5f225a2f88330935831bd9ad4eaf4