### PR TITLE
Configure worker and scheduler environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,18 @@ services:
     image: python-service
     container_name: trainium_worker
     entrypoint: ["python", "worker.py"]
+    environment:
+      # Environment configuration for worker
+      ENVIRONMENT: ${ENVIRONMENT:-development}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      DEBUG: ${DEBUG:-false}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
+      POSTGREST_URL: http://postgrest:3000
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      REDIS_DB: ${REDIS_DB:-0}
     depends_on:
       - python-service
       - redis
@@ -108,6 +120,18 @@ services:
     image: python-service
     container_name: trainium_scheduler
     entrypoint: ["python", "scheduler_daemon.py"]
+    environment:
+      # Environment configuration for scheduler
+      ENVIRONMENT: ${ENVIRONMENT:-development}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      DEBUG: ${DEBUG:-false}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
+      POSTGREST_URL: http://postgrest:3000
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      REDIS_DB: ${REDIS_DB:-0}
     depends_on:
       - python-service
       - redis


### PR DESCRIPTION
## Summary
- Mirror python-service environment variables in worker and scheduler services
- Use internal `db` host for `DATABASE_URL`

## Testing
- `docker compose config` *(fails: command not found)*
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5f4b48e548330bac2ea7213291eda