### PR TITLE
Ensure worker and scheduler build python-service image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,9 @@ services:
 
   # Defines the worker process using the python-service image
   worker:
+    build:
+      context: ./python-service
+      dockerfile: Dockerfile
     image: python-service
     container_name: trainium_worker
     entrypoint: ["python", "worker.py"]
@@ -117,6 +120,9 @@ services:
 
   # Defines the scheduler daemon using the python-service image
   scheduler:
+    build:
+      context: ./python-service
+      dockerfile: Dockerfile
     image: python-service
     container_name: trainium_scheduler
     entrypoint: ["python", "scheduler_daemon.py"]


### PR DESCRIPTION
## Summary
- build worker and scheduler services from python-service Dockerfile to share consistent image

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b5f556af3083308ee1effd1fc789c4