### PR TITLE
Use raw Redis responses for RQ

### DIFF
--- a/python-service/app/services/queue.py
+++ b/python-service/app/services/queue.py
@@ -28,7 +28,6 @@ class QueueService:
                 host=self.settings.redis_host,
                 port=self.settings.redis_port,
                 db=self.settings.redis_db,
-                decode_responses=True
             )
             
             # Test connection

--- a/python-service/worker.py
+++ b/python-service/worker.py
@@ -34,7 +34,6 @@ def main():
             host=settings.redis_host,
             port=settings.redis_port,
             db=settings.redis_db,
-            decode_responses=True
         )
         
         # Test connection


### PR DESCRIPTION
## Summary
- Configure RQ worker and queue service to use Redis without decoding responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b6068e352c83309ce4faf1c0d664fe