### PR TITLE
Include site name in scheduler job payload

### DIFF
--- a/python-service/app/services/scheduler.py
+++ b/python-service/app/services/scheduler.py
@@ -95,9 +95,10 @@ class SchedulerService:
                         self.queue_service.release_redis_lock(lock_key, lock_value)
                         continue
                     
-                    # Enqueue the job
+                    # Enqueue the job with site name included in payload
+                    payload = {**schedule["payload"], "site_name": schedule["site_name"]}
                     job_info = self.queue_service.enqueue_scraping_job(
-                        payload=schedule["payload"],
+                        payload=payload,
                         site_schedule_id=schedule_id,
                         trigger="schedule",
                         run_id=run_id


### PR DESCRIPTION
## Summary
- Ensure scheduler adds site name to job payload before enqueuing so workers persist it

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_68b628e9935083308f19d3addccecd10