### PR TITLE
Persist task IDs after enqueueing jobs

### DIFF
--- a/python-service/app/services/database.py
+++ b/python-service/app/services/database.py
@@ -99,17 +99,18 @@ class DatabaseService:
             logger.error(f"Failed to create scrape run: {str(e)}")
             return None
 
-    async def update_scrape_run_status(self, run_id: str, status: str, 
+    async def update_scrape_run_status(self, run_id: str, status: str,
                                      started_at: Optional[datetime] = None,
                                      finished_at: Optional[datetime] = None,
                                      requested_pages: Optional[int] = None,
                                      completed_pages: Optional[int] = None,
                                      errors_count: Optional[int] = None,
+                                     task_id: Optional[str] = None,
                                      message: Optional[str] = None) -> bool:
-        """Update scrape run status and metrics."""
+        """Update scrape run status, task ID, and metrics."""
         if not self.initialized:
             await self.initialize()
-        
+
         # Build dynamic update query
         updates = ["status = $2", "updated_at = NOW()"]
         params = [run_id, status]
@@ -140,6 +141,11 @@ class DatabaseService:
             params.append(errors_count)
             param_count += 1
             
+        if task_id is not None:
+            updates.append(f"task_id = ${param_count}")
+            params.append(task_id)
+            param_count += 1
+
         if message is not None:
             updates.append(f"message = ${param_count}")
             params.append(message)

--- a/python-service/app/services/scheduler.py
+++ b/python-service/app/services/scheduler.py
@@ -106,11 +106,12 @@ class SchedulerService:
                     
                     if job_info:
                         task_id = job_info["task_id"]
-                        
+
                         # Update scrape run with task_id
                         await self.db_service.update_scrape_run_status(
                             run_id=run_id,
                             status="queued",
+                            task_id=task_id,
                             message=f"Scheduled scrape for {site_name}"
                         )
                         


### PR DESCRIPTION
## Summary
- update scheduler to record task_id in scrape run after enqueue
- allow update_scrape_run_status to optionally set task_id

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'asyncpg')*


------
https://chatgpt.com/codex/tasks/task_e_68b62a49c93883309112ee3027dd536d