### PR TITLE
Refactor evaluation pipeline to crew tasks

### DIFF
--- a/python-service/app/services/evaluation_pipeline.py
+++ b/python-service/app/services/evaluation_pipeline.py
@@ -1,7 +1,8 @@
 """Crew-based job evaluation pipeline orchestrating personas."""
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Any
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, List
 from loguru import logger
 
 from ..models.evaluations import PersonaEvaluation, Decision, EvaluationSummary
@@ -26,8 +27,31 @@ _llm = PersonaLLM()
 _db = get_database_service()
 
 
+@dataclass
+class Task:
+    """Simple async task wrapper."""
+    name: str
+    coro: Callable[[], Awaitable[Any]]
+
+    async def run(self) -> Any:
+        return await self.coro()
+
+
+class Crew:
+    """Sequential executor for persona tasks."""
+
+    def __init__(self, tasks: List[Task]):
+        self.tasks = tasks
+
+    async def run(self) -> List[Any]:
+        results: List[Any] = []
+        for task in self.tasks:
+            results.append(await task.run())
+        return results
+
+
 async def evaluate_job(job_id: str, job: Dict[str, Any], user_id: str) -> EvaluationSummary:
-    """Run motivational personas against a job with user resume context."""
+    """Evaluate a job using a crew of motivational, decision, and judge personas."""
     logger.info(f"Starting evaluation for job {job_id}")
     resume_context: Dict[str, Any] = {}
     if _db.initialized and user_id:
@@ -35,86 +59,107 @@ async def evaluate_job(job_id: str, job: Dict[str, Any], user_id: str) -> Evalua
             resume_context = await _db.get_user_resume_context(user_id)
         except Exception as e:
             logger.error(f"Failed to load resume context: {e}")
-    evaluations: List[PersonaEvaluation] = []
+
+    all_evals: List[PersonaEvaluation] = []
+    motivator_evals: List[PersonaEvaluation] = []
+    decision_evals: List[PersonaEvaluation] = []
+    final_decision: Decision | None = None
+
+    advisors = _catalog.get_personas_by_group("advisory")
+    researcher = next((a for a in advisors if a.id == "researcher"), None)
+    others = [a for a in advisors if a.id != "researcher"]
+    selected_advisors = ([researcher] if researcher else []) + others[:1]
+
+    tasks: List[Task] = []
+
+    def build_motivator_task(persona):
+        async def _run() -> PersonaEvaluation:
+            advisor_notes: List[str] = []
+            for advisor in selected_advisors:
+                note = _llm.advise(advisor.id, job, resume_context)
+                advisor_notes.append(note)
+            result = _llm.evaluate(persona.id, persona.decision_lens, job, resume_context)
+            reason = result["reason"]
+            if advisor_notes:
+                reason = reason + " | " + "; ".join(advisor_notes)
+            evaluation = PersonaEvaluation(
+                job_id=job_id,
+                persona_id=persona.id,
+                vote_bool=result["vote"],
+                confidence=result["confidence"],
+                reason_text=reason,
+                provider=result["provider"],
+                latency_ms=result["latency_ms"],
+            )
+            motivator_evals.append(evaluation)
+            all_evals.append(evaluation)
+            if _db.initialized:
+                try:
+                    await _db.insert_persona_evaluation(evaluation)
+                except Exception as e:  # pragma: no cover - db optional
+                    logger.error(f"Failed to persist evaluation: {e}")
+            return evaluation
+        return _run
+
     for persona in _catalog.get_personas_by_group("motivational"):
-        advisor_notes = []
-        advisors = _catalog.get_personas_by_group("advisory")
-        researcher = next((a for a in advisors if a.id == "researcher"), None)
-        others = [a for a in advisors if a.id != "researcher"]
-        selected = ([researcher] if researcher else []) + others[:1]
-        for advisor in selected:
-            note = _llm.advise(advisor.id, job, resume_context)
-            advisor_notes.append(note)
-        result = _llm.evaluate(persona.id, persona.decision_lens, job, resume_context)
-        reason = result["reason"]
-        if advisor_notes:
-            reason = reason + " | " + "; ".join(advisor_notes)
-        evaluation = PersonaEvaluation(
+        tasks.append(Task(name=persona.id, coro=build_motivator_task(persona)))
+
+    def build_decision_task(persona):
+        async def _run() -> PersonaEvaluation:
+            approvals = sum(1 for e in motivator_evals if e.vote_bool)
+            total = len(motivator_evals) or 1
+            majority = approvals / total
+            vote = majority >= 0.5
+            reason = f"{approvals}/{total} motivators approve"
+            evaluation = PersonaEvaluation(
+                job_id=job_id,
+                persona_id=persona.id,
+                vote_bool=vote,
+                confidence=majority,
+                reason_text=reason,
+                provider="google",
+                latency_ms=0,
+            )
+            decision_evals.append(evaluation)
+            all_evals.append(evaluation)
+            if _db.initialized:
+                try:
+                    await _db.insert_persona_evaluation(evaluation)
+                except Exception as e:  # pragma: no cover - db optional
+                    logger.error(f"Failed to persist decision eval: {e}")
+            return evaluation
+        return _run
+
+    for persona in _catalog.get_personas_by_group("decision"):
+        tasks.append(Task(name=persona.id, coro=build_decision_task(persona)))
+
+    async def judge_task() -> Decision:
+        nonlocal final_decision
+        approvals = sum(1 for e in decision_evals if e.vote_bool)
+        total = len(decision_evals) or 1
+        final_vote = approvals / total >= 0.5
+        confidence = approvals / total
+        reason = f"{approvals}/{total} decision personas approve"
+        decision = Decision(
             job_id=job_id,
-            persona_id=persona.id,
-            vote_bool=result["vote"],
-            confidence=result["confidence"],
+            final_decision_bool=final_vote,
+            confidence=confidence,
             reason_text=reason,
-            provider=result["provider"],
-            latency_ms=result["latency_ms"],
+            created_at=datetime.now(timezone.utc),
         )
-        evaluations.append(evaluation)
+        final_decision = decision
         if _db.initialized:
             try:
-                await _db.insert_persona_evaluation(evaluation)
-            except Exception as e:
-                logger.error(f"Failed to persist evaluation: {e}")
-    decision_evals = await evaluate_decision_personas(job_id, evaluations)
-    final_decision = await aggregate_decision(job_id, decision_evals)
-    summary = EvaluationSummary(job_id=job_id, evaluations=evaluations, decision=final_decision)
+                await _db.insert_decision(decision)
+            except Exception as e:  # pragma: no cover - db optional
+                logger.error(f"Failed to persist final decision: {e}")
+        return decision
+
+    tasks.append(Task(name="judge", coro=judge_task))
+
+    crew = Crew(tasks)
+    await crew.run()
+
+    summary = EvaluationSummary(job_id=job_id, evaluations=all_evals, decision=final_decision)
     logger.info(f"Completed evaluation for job {job_id}")
     return summary
-
-
-async def evaluate_decision_personas(job_id: str, motivators: List[PersonaEvaluation]) -> List[PersonaEvaluation]:
-    """Run decision personas based on motivational outputs."""
-    approvals = sum(1 for e in motivators if e.vote_bool)
-    total = len(motivators) or 1
-    majority = approvals / total
-    decision_evals: List[PersonaEvaluation] = []
-    for persona in _catalog.get_personas_by_group("decision"):
-        vote = majority >= 0.5
-        reason = f"{approvals}/{total} motivators approve"
-        evaluation = PersonaEvaluation(
-            job_id=job_id,
-            persona_id=persona.id,
-            vote_bool=vote,
-            confidence=majority,
-            reason_text=reason,
-            provider="google",
-            latency_ms=0,
-        )
-        decision_evals.append(evaluation)
-        if _db.initialized:
-            try:
-                await _db.insert_persona_evaluation(evaluation)
-            except Exception as e:
-                logger.error(f"Failed to persist decision eval: {e}")
-    return decision_evals
-
-
-async def aggregate_decision(job_id: str, decisions: List[PersonaEvaluation]) -> Decision:
-    """Judge persona synthesizes final decision."""
-    approvals = sum(1 for e in decisions if e.vote_bool)
-    total = len(decisions) or 1
-    final_vote = approvals / total >= 0.5
-    confidence = approvals / total
-    reason = f"{approvals}/{total} decision personas approve"
-    decision = Decision(
-        job_id=job_id,
-        final_decision_bool=final_vote,
-        confidence=confidence,
-        reason_text=reason,
-        created_at=datetime.now(timezone.utc),
-    )
-    if _db.initialized:
-        try:
-            await _db.insert_decision(decision)
-        except Exception as e:
-            logger.error(f"Failed to persist final decision: {e}")
-    return decision

--- a/python-service/test_evaluation_pipeline.py
+++ b/python-service/test_evaluation_pipeline.py
@@ -5,11 +5,19 @@ from app.services.evaluation_pipeline import evaluate_job
 def test_evaluate_job_pipeline():
     job = {"title": "Remote Engineer", "description": "Great remote role with salary"}
     summary = asyncio.run(evaluate_job("1", job, user_id="user-1"))
+
+    # judge decision
     assert summary.decision.final_decision_bool is True
-    assert summary.decision.reason_text
+    assert "decision personas approve" in summary.decision.reason_text
     assert 0 <= summary.decision.confidence <= 1
-    # ensure motivational personas evaluated
-    assert len(summary.evaluations) == 5
-    first = summary.evaluations[0]
-    assert first.reason_text
-    assert 0 <= first.confidence <= 1
+
+    # motivational and decision personas ran
+    ids = {e.persona_id for e in summary.evaluations}
+    motivators = {"builder", "maximizer", "harmonizer", "pathfinder", "adventurer"}
+    decisions = {"visionary", "realist", "guardian"}
+    assert motivators.issubset(ids)
+    assert decisions.issubset(ids)
+
+    # advisory delegation produced notes
+    motivator_reasons = [e.reason_text for e in summary.evaluations if e.persona_id in motivators]
+    assert any("notes" in r for r in motivator_reasons)


### PR DESCRIPTION
## Summary
- replace manual persona loops with Task/Crew orchestration from PersonaCatalog
- delegate motivational personas to advisory notes and run decision and judge as separate tasks
- expand evaluation pipeline test to assert multi-agent flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest test_evaluation_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6767e760483308bfc5287a1f2b120