### PR TITLE
Use LLM for decision and judge personas

### DIFF
--- a/python-service/test_evaluation_pipeline.py
+++ b/python-service/test_evaluation_pipeline.py
@@ -8,7 +8,7 @@ def test_evaluate_job_pipeline():
 
     # judge decision
     assert summary.decision.final_decision_bool is True
-    assert "decision personas approve" in summary.decision.reason_text
+    assert "judge" in summary.decision.reason_text
     assert 0 <= summary.decision.confidence <= 1
 
     # motivational and decision personas ran


### PR DESCRIPTION
## Summary
- Evaluate decision personas with the LLM using motivational outcomes as context and record returned confidence and reasoning.
- Aggregate decision persona results through the judge persona using the LLM for the final verdict.
- Update evaluation pipeline test to reflect judge reasoning.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*
- `pytest -q test_evaluation_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68b677e535ac8330bb72cbd0639acff0