### PR TITLE
Validate evaluation confidence range

### DIFF
--- a/python-service/app/models/evaluations.py
+++ b/python-service/app/models/evaluations.py
@@ -9,7 +9,7 @@ class PersonaEvaluation(BaseModel):
     job_id: str
     persona_id: str
     vote_bool: bool
-    confidence: float
+    confidence: float = Field(ge=0.0, le=1.0)
     reason_text: str
     provider: str
     latency_ms: int
@@ -20,7 +20,7 @@ class Decision(BaseModel):
     """Final decision produced by judge persona."""
     job_id: str
     final_decision_bool: bool
-    confidence: float
+    confidence: float = Field(ge=0.0, le=1.0)
     reason_text: str
     method: str = "judge"
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/python-service/test_evaluations_model.py
+++ b/python-service/test_evaluations_model.py
@@ -1,0 +1,46 @@
+import pytest
+from pydantic import ValidationError
+
+from app.models.evaluations import PersonaEvaluation, Decision
+
+
+def test_persona_evaluation_confidence_validation():
+    """PersonaEvaluation rejects confidence outside [0, 1]."""
+    with pytest.raises(ValidationError):
+        PersonaEvaluation(
+            job_id="job",
+            persona_id="persona",
+            vote_bool=True,
+            confidence=1.5,
+            reason_text="reason",
+            provider="provider",
+            latency_ms=10,
+        )
+    with pytest.raises(ValidationError):
+        PersonaEvaluation(
+            job_id="job",
+            persona_id="persona",
+            vote_bool=True,
+            confidence=-0.1,
+            reason_text="reason",
+            provider="provider",
+            latency_ms=10,
+        )
+
+
+def test_decision_confidence_validation():
+    """Decision rejects confidence outside [0, 1]."""
+    with pytest.raises(ValidationError):
+        Decision(
+            job_id="job",
+            final_decision_bool=True,
+            confidence=1.2,
+            reason_text="reason",
+        )
+    with pytest.raises(ValidationError):
+        Decision(
+            job_id="job",
+            final_decision_bool=True,
+            confidence=-0.2,
+            reason_text="reason",
+        )


### PR DESCRIPTION
## Summary
- enforce confidence in PersonaEvaluation and Decision to be between 0 and 1
- test validation errors for out-of-range confidence values

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/test_evaluations_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68b683282dc4833097c4b74a3d4e39d9