### PR TITLE
feat: support multiple models per persona

### DIFF
--- a/python-service/app/services/persona_loader.py
+++ b/python-service/app/services/persona_loader.py
@@ -13,7 +13,7 @@ class Persona:
     tone: str
     capabilities: List[str]
     crew_manifest_ref: str
-    provider: str
+    models: List[Dict[str, str]]
 
 
 class PersonaCatalog:
@@ -33,7 +33,7 @@ class PersonaCatalog:
                     tone=item.get("tone", ""),
                     capabilities=item.get("capabilities", []),
                     crew_manifest_ref=item.get("crew_manifest_ref", ""),
-                    provider=item.get("models", [{}])[0].get("provider", "")
+                    models=item.get("models", [])
                 )
                 self.personas[persona.id] = persona
                 ids.append(persona.id)
@@ -45,3 +45,12 @@ class PersonaCatalog:
 
     def get(self, persona_id: str) -> Persona:
         return self.personas[persona_id]
+
+    def get_models(self, persona_id: str) -> List[Dict[str, str]]:
+        """Return available models for a persona."""
+        return self.get(persona_id).models
+
+    def get_default_model(self, persona_id: str) -> Dict[str, str]:
+        """Return the default provider/model pair for a persona."""
+        models = self.get_models(persona_id)
+        return models[0] if models else {"provider": "", "model": ""}


### PR DESCRIPTION
## Summary
- allow personas to define multiple provider/model pairs
- load full model list from persona catalog YAML
- add helpers to access persona models and default selection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: async def functions are not natively supported, Deploy migration file missing, coroutine object does not support async with, NameError ScrapedJob, assertions failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b688adb9348330934509e0df5f1009