### PR TITLE
Modular LLM client dispatch for persona evaluations

### DIFF
--- a/python-service/app/services/evaluation_pipeline.py
+++ b/python-service/app/services/evaluation_pipeline.py
@@ -77,7 +77,15 @@ class EvaluationPipeline:
         for persona in self.catalog.get_personas_by_group("decision"):
             start = time.monotonic()
             logger.info(f"Starting evaluation for persona {persona.id}")
-            result = self.llm.evaluate(persona.id, persona.decision_lens, job, context)
+            model = self.catalog.get_default_model(persona.id)
+            result = self.llm.evaluate(
+                persona.id,
+                persona.decision_lens,
+                job,
+                context,
+                provider=model["provider"],
+                model=model["model"],
+            )
             latency_ms = int((time.monotonic() - start) * 1000)
             logger.info(
                 f"Completed evaluation for persona {persona.id} in {latency_ms} ms",
@@ -118,7 +126,15 @@ class EvaluationPipeline:
         }
         start = time.monotonic()
         logger.info(f"Starting evaluation for persona {judge.id}")
-        result = self.llm.evaluate(judge.id, judge.decision_lens, job, context)
+        model = self.catalog.get_default_model(judge.id)
+        result = self.llm.evaluate(
+            judge.id,
+            judge.decision_lens,
+            job,
+            context,
+            provider=model["provider"],
+            model=model["model"],
+        )
         latency_ms = int((time.monotonic() - start) * 1000)
         logger.info(
             f"Completed evaluation for persona {judge.id} in {latency_ms} ms",
@@ -163,12 +179,25 @@ class EvaluationPipeline:
             async def _run() -> PersonaEvaluation:
                 advisor_notes: List[str] = []
                 for advisor in selected_advisors:
-                    note = self.llm.advise(advisor.id, job, resume_context)
+                    model = self.catalog.get_default_model(advisor.id)
+                    note = self.llm.advise(
+                        advisor.id,
+                        job,
+                        resume_context,
+                        provider=model["provider"],
+                        model=model["model"],
+                    )
                     advisor_notes.append(note)
                 start = time.monotonic()
                 logger.info(f"Starting evaluation for persona {persona.id}")
+                model = self.catalog.get_default_model(persona.id)
                 result = self.llm.evaluate(
-                    persona.id, persona.decision_lens, job, resume_context
+                    persona.id,
+                    persona.decision_lens,
+                    job,
+                    resume_context,
+                    provider=model["provider"],
+                    model=model["model"],
                 )
                 latency_ms = int((time.monotonic() - start) * 1000)
                 logger.info(

--- a/python-service/app/services/llm_clients.py
+++ b/python-service/app/services/llm_clients.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Lightweight LLM client implementations.
+
+This module defines a ``BaseLLMClient`` along with concrete clients for
+Gemini and HuggingFace models.  The clients here are intentionally
+minimal and serve primarily as extension points; they provide a common
+interface used by ``PersonaLLM`` for dispatching calls based on provider
+and model identifiers.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, Tuple
+
+
+class BaseLLMClient(ABC):
+    """Abstract base class for simple text generation clients."""
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+
+    @abstractmethod
+    def generate(self, prompt: str, **kwargs: Dict) -> str:
+        """Generate text for ``prompt``.
+
+        Concrete implementations may choose to ignore ``kwargs``.  The
+        method is synchronous to keep tests simple.
+        """
+
+
+class GeminiClient(BaseLLMClient):
+    """Placeholder client for Google's Gemini models."""
+
+    provider = "google"
+
+    def generate(self, prompt: str, **kwargs: Dict) -> str:  # pragma: no cover - trivial
+        return f"Gemini({self.model}) response to: {prompt}"[:100]
+
+
+class HuggingFaceClient(BaseLLMClient):
+    """Placeholder client for HuggingFace models."""
+
+    provider = "huggingface"
+
+    def generate(self, prompt: str, **kwargs: Dict) -> str:  # pragma: no cover - trivial
+        return f"HF({self.model}) response to: {prompt}"[:100]
+
+
+_CLIENT_FACTORIES: Dict[str, type[BaseLLMClient]] = {
+    GeminiClient.provider: GeminiClient,
+    HuggingFaceClient.provider: HuggingFaceClient,
+}
+
+
+def create_llm_client(provider: str, model: str) -> BaseLLMClient:
+    """Factory creating a client for ``provider`` and ``model``.
+
+    Args:
+        provider: LLM provider identifier, e.g. ``"google"``.
+        model:    Model name associated with the provider.
+    """
+    try:
+        factory = _CLIENT_FACTORIES[provider]
+    except KeyError:  # pragma: no cover - defensive
+        raise ValueError(f"Unsupported provider: {provider}")
+    return factory(model)

--- a/python-service/app/services/persona_llm.py
+++ b/python-service/app/services/persona_llm.py
@@ -1,15 +1,49 @@
-"""Deterministic LLM used for persona evaluations in tests."""
-from typing import Dict, Any
+"""Utilities for routing persona requests to provider-specific LLMs."""
+from __future__ import annotations
+
+from typing import Dict, Any, Tuple
+
+from .llm_clients import BaseLLMClient, create_llm_client
 
 
 class PersonaLLM:
-    """Simple heuristic LLM replacement for tests."""
+    """Dispatches persona calls to provider/model specific clients.
 
-    def advise(self, advisor_id: str, job: Dict[str, Any], context: Dict[str, Any] | None = None) -> str:
+    The class lazily instantiates LLM clients and caches them so that
+    multiple personas using the same ``(provider, model)`` pair share the
+    underlying client instance.
+    """
+
+    def __init__(self) -> None:
+        self._clients: Dict[Tuple[str, str], BaseLLMClient] = {}
+
+    def _get_client(self, provider: str, model: str) -> BaseLLMClient:
+        key = (provider, model)
+        if key not in self._clients:
+            self._clients[key] = create_llm_client(provider, model)
+        return self._clients[key]
+
+    def advise(
+        self,
+        advisor_id: str,
+        job: Dict[str, Any],
+        context: Dict[str, Any] | None = None,
+        *,
+        provider: str,
+        model: str,
+    ) -> str:
+        """Generate advisory notes for a persona."""
+
+        client = self._get_client(provider, model)
         desc = job.get("description", "").lower()
-        base = f"{advisor_id} notes salary info" if "salary" in desc else f"{advisor_id} finds no salary info"
+        base = (
+            f"{advisor_id} notes salary info"
+            if "salary" in desc
+            else f"{advisor_id} finds no salary info"
+        )
         if context and context.get("standard_job_roles"):
             base += f" with roles {len(context['standard_job_roles'])}"
+        client.generate(base)  # placeholder call to demonstrate dispatch
         return base
 
     def evaluate(
@@ -18,17 +52,24 @@ class PersonaLLM:
         decision_lens: str,
         job: Dict[str, Any],
         context: Dict[str, Any] | None = None,
+        *,
+        provider: str,
+        model: str,
     ) -> Dict[str, Any]:
+        """Evaluate a job from a persona's perspective."""
+
+        client = self._get_client(provider, model)
         desc = job.get("description", "").lower()
         approve = "remote" in desc or "flexible" in desc
         reason = f"{persona_id} {'approves' if approve else 'rejects'}: {decision_lens}"
         if context and context.get("strategic_narratives"):
             reason += " | narratives considered"
+        client.generate(reason)  # placeholder dispatch
         return {
             "vote": approve,
             "reason": reason,
             "confidence": 0.8 if approve else 0.2,
-            "provider": "google",
-            "model": "gemini-2.5-flash-lite",
+            "provider": provider,
+            "model": model,
             "latency_ms": 0,
         }

--- a/python-service/test_evaluation_pipeline.py
+++ b/python-service/test_evaluation_pipeline.py
@@ -33,9 +33,20 @@ class FakeCatalog:
     def get_personas_by_group(self, group: str) -> List[FakePersona]:
         return self.groups.get(group, [])
 
+    def get_default_model(self, persona_id: str) -> Dict[str, str]:
+        return {"provider": "fake", "model": "test-model"}
+
 
 class FakeLLM:
-    def advise(self, advisor_id: str, job: Dict[str, Any], context: Dict[str, Any] | None = None) -> str:
+    def advise(
+        self,
+        advisor_id: str,
+        job: Dict[str, Any],
+        context: Dict[str, Any] | None = None,
+        *,
+        provider: str,
+        model: str,
+    ) -> str:
         return f"{advisor_id} notes"
 
     def evaluate(
@@ -44,6 +55,9 @@ class FakeLLM:
         decision_lens: str,
         job: Dict[str, Any],
         context: Dict[str, Any] | None = None,
+        *,
+        provider: str,
+        model: str,
     ) -> Dict[str, Any]:
         approve = "remote" in job.get("description", "").lower()
         reason = f"{persona_id} {'approves' if approve else 'rejects'}"
@@ -51,7 +65,8 @@ class FakeLLM:
             "vote": approve,
             "confidence": 0.8 if approve else 0.2,
             "reason": reason,
-            "provider": "fake",
+            "provider": provider,
+            "model": model,
         }
 
 


### PR DESCRIPTION
## Summary
- add BaseLLMClient with Gemini and HuggingFace implementations
- cache provider/model-specific clients inside PersonaLLM
- update evaluation pipeline and tests to route persona requests to appropriate LLM provider

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: async plugin missing, missing DB scripts, idempotency assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68b68982e68c8330bf991f3c125424f4