### PR TITLE
Include persona model in evaluation records

### DIFF
--- a/python-service/app/models/evaluations.py
+++ b/python-service/app/models/evaluations.py
@@ -12,6 +12,7 @@ class PersonaEvaluation(BaseModel):
     confidence: float = Field(ge=0.0, le=1.0)
     reason_text: str
     provider: str
+    model: str
     latency_ms: int
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 

--- a/python-service/app/services/database.py
+++ b/python-service/app/services/database.py
@@ -212,8 +212,8 @@ class DatabaseService:
             await self.initialize()
 
         query = """
-        INSERT INTO evaluations (job_id, persona_id, vote_bool, confidence, reason_text, provider, latency_ms, created_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        INSERT INTO evaluations (job_id, persona_id, vote_bool, confidence, reason_text, provider, model, latency_ms, created_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         """
 
         try:
@@ -226,6 +226,7 @@ class DatabaseService:
                     evaluation.confidence,
                     evaluation.reason_text,
                     evaluation.provider,
+                    evaluation.model,
                     evaluation.latency_ms,
                     evaluation.created_at,
                 )

--- a/python-service/app/services/evaluation_pipeline.py
+++ b/python-service/app/services/evaluation_pipeline.py
@@ -97,6 +97,7 @@ class EvaluationPipeline:
                 confidence=result["confidence"],
                 reason_text=result["reason"],
                 provider=result["provider"],
+                model=result["model"],
                 latency_ms=latency_ms,
             )
             decision_evals.append(evaluation)
@@ -213,6 +214,7 @@ class EvaluationPipeline:
                     confidence=result["confidence"],
                     reason_text=reason,
                     provider=result["provider"],
+                    model=result["model"],
                     latency_ms=latency_ms,
                 )
                 motivator_evals.append(evaluation)

--- a/python-service/test_evaluations_model.py
+++ b/python-service/test_evaluations_model.py
@@ -14,6 +14,7 @@ def test_persona_evaluation_confidence_validation():
             confidence=1.5,
             reason_text="reason",
             provider="provider",
+            model="model",
             latency_ms=10,
         )
     with pytest.raises(ValidationError):
@@ -24,6 +25,7 @@ def test_persona_evaluation_confidence_validation():
             confidence=-0.1,
             reason_text="reason",
             provider="provider",
+            model="model",
             latency_ms=10,
         )
 


### PR DESCRIPTION
## Summary
- Add `model` field to `PersonaEvaluation`
- Pass catalog `provider` and `model` to LLM calls and store them with evaluations
- Persist `provider` and `model` when inserting evaluations into the database

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/test_evaluations_model.py python-service/test_evaluation_pipeline.py -q`
- `pytest -q` *(fails: async plugin missing, missing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b68a9ec63c83309f1ffc2c504a265f