### PR TITLE
feat: add provider API key config and resolver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ DEBUG=false
 
 # API keys
 GEMINI_API_KEY=your_gemini_api_key
+OPENAI_API_KEY=your_openai_api_key
+HUGGING_FACE_API_KEY=your_hugging_face_api_key
+OLLAMA_API_KEY=your_ollama_api_key
+ANTHROPIC_API_KEY=your_anthropic_api_key
 
 # Redis configuration
 REDIS_HOST=redis

--- a/python-service/README.md
+++ b/python-service/README.md
@@ -101,6 +101,10 @@ The service uses environment variables for configuration:
 - `LOG_LEVEL`: Logging level (DEBUG, INFO, WARNING, ERROR)
 - `DEBUG`: Enable debug mode (true/false)
 - `GEMINI_API_KEY`: Google Gemini AI API key
+- `OPENAI_API_KEY`: OpenAI API key
+- `HUGGING_FACE_API_KEY`: Hugging Face API key
+- `OLLAMA_API_KEY`: Ollama API key
+- `ANTHROPIC_API_KEY`: Anthropic API key
 - `POSTGREST_URL`: PostgREST backend URL
 
 ## Future Enhancements

--- a/python-service/app/core/config.py
+++ b/python-service/app/core/config.py
@@ -1,4 +1,5 @@
 """Core application configuration and settings."""
+
 from typing import Optional
 import os
 from loguru import logger
@@ -7,44 +8,50 @@ from dotenv import load_dotenv
 
 class Settings:
     """Application settings and configuration."""
-    
+
     def __init__(self):
         load_dotenv()
         # API Configuration
         self.app_name: str = "Trainium Python AI Service"
         self.app_version: str = "1.0.0"
         self.debug: bool = os.getenv("DEBUG", "false").lower() == "true"
-        
+
         # Server Configuration
         self.host: str = os.getenv("HOST", "0.0.0.0")
         self.port: int = int(os.getenv("PORT", "8000"))
-        
+
         # Logging Configuration
         self.log_level: str = os.getenv("LOG_LEVEL", "INFO")
-        self.log_format: str = "{time:YYYY-MM-DD HH:mm:ss} | {level} | {name}:{function}:{line} - {message}"
-        
-        # Gemini AI Configuration (for future use)
+        self.log_format: str = (
+            "{time:YYYY-MM-DD HH:mm:ss} | {level} | {name}:{function}:{line} - {message}"
+        )
+
+        # AI Provider API Keys
         self.gemini_api_key: Optional[str] = os.getenv("GEMINI_API_KEY")
-        
+        self.openai_api_key: Optional[str] = os.getenv("OPENAI_API_KEY")
+        self.huggingface_api_key: Optional[str] = os.getenv("HUGGING_FACE_API_KEY")
+        self.ollama_api_key: Optional[str] = os.getenv("OLLAMA_API_KEY")
+        self.anthropic_api_key: Optional[str] = os.getenv("ANTHROPIC_API_KEY")
+
         # PostgREST Configuration (for future integration)
         self.postgrest_url: str = os.getenv("POSTGREST_URL", "http://postgrest:3000")
-        
+
         # Database Configuration for direct access
         self.database_url: str = os.getenv("DATABASE_URL", "")
         if not self.database_url:
             raise ValueError("DATABASE_URL is not set")
-        
+
         # Redis Configuration for queue system
         self.redis_url: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")
         self.redis_host: str = os.getenv("REDIS_HOST", "localhost")
         self.redis_port: int = int(os.getenv("REDIS_PORT", "6379"))
         self.redis_db: int = int(os.getenv("REDIS_DB", "0"))
-        
+
         # Queue Configuration
         self.rq_queue_name: str = os.getenv("RQ_QUEUE_NAME", "scraping")
         self.rq_result_ttl: int = int(os.getenv("RQ_RESULT_TTL", "3600"))  # 1 hour
         self.rq_job_timeout: int = int(os.getenv("RQ_JOB_TIMEOUT", "900"))  # 15 minutes
-        
+
         # Environment-based configuration
         self.environment: str = os.getenv("ENVIRONMENT", "development")
 
@@ -55,20 +62,20 @@ settings = Settings()
 
 def configure_logging():
     """Configure structured logging for the application."""
-    
+
     # Remove default logger
     logger.remove()
-    
+
     # Add structured logging
     logger.add(
-        sink=lambda message: print(message, end=''),
+        sink=lambda message: print(message, end=""),
         format=settings.log_format,
         level=settings.log_level,
         colorize=True,
         backtrace=True,
-        diagnose=True
+        diagnose=True,
     )
-    
+
     # Add file logging for production
     if settings.environment == "production":
         logger.add(
@@ -76,10 +83,23 @@ def configure_logging():
             rotation="1 day",
             retention="30 days",
             format=settings.log_format,
-            level=settings.log_level
+            level=settings.log_level,
         )
-    
+
     logger.info(f"Logging configured with level: {settings.log_level}")
+
+
+def resolve_api_key(provider: str) -> Optional[str]:
+    """Return the API key for a given provider name."""
+    provider = provider.lower()
+    mapping = {
+        "openai": settings.openai_api_key,
+        "huggingface": settings.huggingface_api_key,
+        "ollama": settings.ollama_api_key,
+        "gemini": settings.gemini_api_key,
+        "anthropic": settings.anthropic_api_key,
+    }
+    return mapping.get(provider)
 
 
 def get_settings() -> Settings:


### PR DESCRIPTION
## Summary
- add optional API key settings for OpenAI, Hugging Face, Ollama, and Anthropic
- provide `resolve_api_key` helper for persona provider lookup
- document new API key environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `cd python-service && pytest` *(fails: async plugin missing, missing files, persistence assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68b68c216cf083308c3cd6954e7e5227