### PR TITLE
docs: switch Llama-4 setup to Hugging Face

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,6 @@ DEBUG=false
 GEMINI_API_KEY=your_gemini_api_key
 OPENAI_API_KEY=your_openai_api_key
 HUGGING_FACE_API_KEY=your_hugging_face_api_key
-OLLAMA_API_KEY=your_ollama_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
 
 # Redis configuration

--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ Run the full stack with Docker:
 docker-compose up --build
 ```
 
+## Use Llama-4 for CrewAI personas
+
+1. **Update persona definitions** – In `python-service/app/services/persona_catalog.yaml` set each persona to the Hugging Face model:
+
+   ```yaml
+   models:
+     - provider: huggingface
+       model: meta-llama/Llama-4
+   ```
+
+2. **Use the Hugging Face client** – `python-service/app/services/llm_clients.py` already includes a minimal `HuggingFaceClient`. Extend it if custom behavior is needed and ensure it's registered in `_CLIENT_FACTORIES`.
+
+3. **Expose credentials** – Set `HUGGING_FACE_API_KEY` in `.env`; this key is forwarded to containers by `docker-compose.yml`.
+
+4. **Make the model available** – The `python-service/Dockerfile` installs Hugging Face dependencies and downloads the `meta-llama/Llama-4` weights during the image build. Rebuild to apply:
+
+   ```bash
+   docker-compose up --build
+   ```
+
+With these steps, the python service will have Llama‑4 locally for CrewAI personas.
+
 ## Checks
 
 Run these commands before committing:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       DEBUG: ${DEBUG:-false}
       GEMINI_API_KEY: ${GEMINI_API_KEY}
+      HUGGING_FACE_API_KEY: ${HUGGING_FACE_API_KEY}
       POSTGREST_URL: http://postgrest:3000
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
@@ -108,6 +109,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       DEBUG: ${DEBUG:-false}
       GEMINI_API_KEY: ${GEMINI_API_KEY}
+      HUGGING_FACE_API_KEY: ${HUGGING_FACE_API_KEY}
       POSTGREST_URL: http://postgrest:3000
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
@@ -132,6 +134,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       DEBUG: ${DEBUG:-false}
       GEMINI_API_KEY: ${GEMINI_API_KEY}
+      HUGGING_FACE_API_KEY: ${HUGGING_FACE_API_KEY}
       POSTGREST_URL: http://postgrest:3000
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}

--- a/python-service/Dockerfile
+++ b/python-service/Dockerfile
@@ -4,6 +4,8 @@ FROM python:3.11-slim
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
+ARG HUGGING_FACE_API_KEY
+ENV HUGGING_FACE_API_KEY=${HUGGING_FACE_API_KEY}
 
 # Set the working directory
 WORKDIR /app
@@ -29,12 +31,18 @@ RUN useradd --create-home --shell /bin/bash app \
     && chown -R app:app /app
 USER app
 
+# Preload the Llama-4 model from Hugging Face
+RUN python - <<'PY'
+from huggingface_hub import snapshot_download
+snapshot_download('meta-llama/Llama-4')
+PY
+
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-# Expose port
+# Expose application port
 EXPOSE 8000
 
-# Run the application
+# Run the FastAPI app
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/python-service/README.md
+++ b/python-service/README.md
@@ -103,7 +103,6 @@ The service uses environment variables for configuration:
 - `GEMINI_API_KEY`: Google Gemini AI API key
 - `OPENAI_API_KEY`: OpenAI API key
 - `HUGGING_FACE_API_KEY`: Hugging Face API key
-- `OLLAMA_API_KEY`: Ollama API key
 - `ANTHROPIC_API_KEY`: Anthropic API key
 - `POSTGREST_URL`: PostgREST backend URL
 

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -27,3 +27,6 @@ grpcio==1.66.2
 protobuf==5.28.3
 grpcio-status==1.66.2
 googleapis-common-protos==1.63.2
+
+# Local Llama-4 via Hugging Face
+transformers==4.46.0


### PR DESCRIPTION
## Summary
- document how to switch CrewAI personas to use local Hugging Face Llama-4
- preload Llama-4 weights in python-service Docker image and forward `HUGGING_FACE_API_KEY`

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b6979e684083308ca6d0f81597f71e