### PR TITLE
Ensure unique resume accomplishment IDs

### DIFF
--- a/components/ResumeEditorView.tsx
+++ b/components/ResumeEditorView.tsx
@@ -6,6 +6,7 @@ import { AchievementRefinementPanel } from './AchievementRefinementPanel';
 import { SummaryRefinementPanel } from './SummaryRefinementPanel';
 import { CombineAchievementsModal } from './CombineAchievementsModal';
 import * as geminiService from '../services/geminiService';
+import { ensureUniqueAchievementIds } from '../utils/resume';
 import { DownloadResumeStep } from './DownloadResumeStep';
 
 interface ResumeEditorViewProps {
@@ -95,9 +96,10 @@ export const ResumeEditorView = ({ resume, activeNarrative, onSave, onCancel, on
             if (!deepCopy.content) deepCopy.content = {};
             if (!deepCopy.content.work_experience) deepCopy.content.work_experience = [];
 
+            deepCopy.content = ensureUniqueAchievementIds(deepCopy.content);
+
             (deepCopy.content.work_experience || []).forEach((exp: WorkExperience) => {
                 (exp.accomplishments || []).forEach((acc: ResumeAccomplishment, index: number) => {
-                    if (!acc.achievement_id) acc.achievement_id = uuidv4();
                     if (acc.original_description === undefined) acc.original_description = acc.description;
                     if (acc.order_index === undefined) acc.order_index = index;
                 });

--- a/components/ResumeInputStep.tsx
+++ b/components/ResumeInputStep.tsx
@@ -5,6 +5,7 @@ import { ArrowRightIcon, LoadingSpinner } from './IconComponents';
 import { BaseResume, Resume, Prompt, KeywordsResult, UserProfile, ResumeHeader, StrategicNarrative } from '../types';
 import { BLANK_RESUME_CONTENT } from '../mockData';
 import * as apiService from '../services/apiService';
+import { ensureUniqueAchievementIds } from '../utils/resume';
 
 interface SelectResumeStepProps {
   baseResumes: BaseResume[];
@@ -68,6 +69,7 @@ export const SelectResumeStep = ({ baseResumes, onNext, isLoading, keywords, use
         }
         
         if (resumeToProcess) {
+            resumeToProcess = ensureUniqueAchievementIds(resumeToProcess);
             onNext(resumeToProcess);
         } else {
             setError("Could not find or parse the selected resume.");

--- a/components/TailorResumeStep.tsx
+++ b/components/TailorResumeStep.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useCallback, useRef, useLayoutEffect, useEffect } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { Resume, KeywordsResult, ResumeAccomplishment, Prompt, UserProfile, StrategicNarrative, KeywordDetail, SkillSection, AchievementScore } from '../types';
 import { ArrowRightIcon, LoadingSpinner, SparklesIcon, XCircleIcon } from './IconComponents';
 import * as geminiService from '../services/geminiService';
+import { ensureUniqueAchievementIds } from '../utils/resume';
 
 interface TailorResumeStepProps {
   finalResume: Resume;
@@ -120,7 +120,15 @@ export const TailorResumeStep = (props: TailorResumeStepProps) => {
     const [newKeywordInput, setNewKeywordInput] = useState('');
     const [refiningId, setRefiningId] = useState<string | null>(null);
     const [isRecalculating, setIsRecalculating] = useState(false);
-    
+
+    useEffect(() => {
+        if (!finalResume) return;
+        const updated = ensureUniqueAchievementIds(finalResume);
+        if (updated !== finalResume) {
+            setFinalResume(updated);
+        }
+    }, [finalResume, setFinalResume]);
+
 
     const handleSummaryParagraphChange = useCallback((newParagraph: string) => {
         setFinalResume(prev => prev ? { ...prev, summary: { ...prev.summary, paragraph: newParagraph, bullets: [] } } : null);

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -10,6 +10,7 @@ import {
 } from '../types';
 import { API_BASE_URL, USER_ID, FASTAPI_BASE_URL } from '../constants';
 import { v4 as uuidv4 } from 'uuid';
+import { ensureUniqueAchievementIds } from '../utils/resume';
 
 // --- API Helpers ---
 
@@ -461,7 +462,7 @@ export const getResumeContent = async (resumeId: string): Promise<Resume> => {
     
     // Resume-specific header and summary are assumed to be on the resumes table itself for simplicity now.
     // This aligns with the user's schema feedback.
-    const assembledContent: Resume = {
+      const assembledContent: Resume = {
         header: {
             first_name: userProfile.first_name || '',
             last_name: userProfile.last_name || '',
@@ -495,10 +496,11 @@ export const getResumeContent = async (resumeId: string): Promise<Resume> => {
             heading: sec.heading,
             items: (sec.resume_skill_items || []).map((item: any) => item.item_text)
         }))
-    };
+      };
 
-    return JSON.parse(JSON.stringify(assembledContent));
-};
+      const sanitized = ensureUniqueAchievementIds(assembledContent);
+      return JSON.parse(JSON.stringify(sanitized));
+  };
 
 export const saveResumeContent = async (resumeId: string, content: Resume): Promise<void> => {
     // --- 1. Update User Profile Info (if any) ---

--- a/utils/resume.ts
+++ b/utils/resume.ts
@@ -1,0 +1,30 @@
+import { v4 as uuidv4 } from 'uuid';
+import { WorkExperience, ResumeAccomplishment } from '../types';
+
+/**
+ * Ensures every accomplishment in the resume has a unique `achievement_id`.
+ * Missing or duplicate IDs are replaced with a fresh uuid.
+ * Returns the original resume if no changes were necessary to avoid re-renders.
+ */
+export function ensureUniqueAchievementIds<T extends { work_experience: WorkExperience[] }>(resume: T): T {
+  const seen = new Set<string>();
+  let changed = false;
+
+  const work_experience = resume.work_experience.map((exp: WorkExperience) => {
+    const newAccs = (exp.accomplishments || []).map((acc: ResumeAccomplishment) => {
+      let id = acc.achievement_id;
+      if (!id || seen.has(id)) {
+        id = uuidv4();
+        changed = true;
+      }
+      seen.add(id);
+      return id === acc.achievement_id ? acc : { ...acc, achievement_id: id };
+    });
+    if (newAccs.some((acc, idx) => acc !== exp.accomplishments[idx])) {
+      return { ...exp, accomplishments: newAccs } as WorkExperience;
+    }
+    return exp;
+  });
+
+  return changed ? { ...(resume as any), work_experience } : resume;
+}


### PR DESCRIPTION
## Summary
- add helper to generate fresh UUIDs for missing or duplicate resume accomplishment IDs
- sanitize resumes on load and selection to ensure unique achievement IDs
- initialize TailorResumeStep by deduplicating accomplishment IDs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6a0b6238c833081256182347d0809