### PR TITLE
Add skills analysis task to evaluation crew

### DIFF
--- a/python-service/app/services/crewai_job_review.py
+++ b/python-service/app/services/crewai_job_review.py
@@ -15,6 +15,10 @@ from dataclasses import dataclass, asdict
 from ..core.config import get_settings
 from ..models.jobspy import ScrapedJob
 from .database import get_database_service
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from .evaluation_pipeline import Task
 
 
 @dataclass
@@ -172,6 +176,16 @@ class SkillsAnalysisAgent:
                 required_skills.append(skill)
         
         return required_skills, preferred_skills
+
+
+def build_skills_task(job: Dict[str, Any]) -> "Task":
+    """Create a task that runs the SkillsAnalysisAgent."""
+    from .evaluation_pipeline import Task  # Local import to avoid circular dependency
+
+    async def _run() -> Dict[str, Any]:
+        return SkillsAnalysisAgent().analyze(job)
+
+    return Task(name="skills_analysis", coro=_run)
 
 
 class CompensationAnalysisAgent:

--- a/python-service/app/services/evaluation_pipeline.py
+++ b/python-service/app/services/evaluation_pipeline.py
@@ -9,6 +9,7 @@ from loguru import logger
 from ..models.evaluations import PersonaEvaluation, Decision, EvaluationSummary
 from .persona_loader import PersonaCatalog
 from .persona_llm import PersonaLLM
+from .crewai_job_review import build_skills_task
 try:
     from .database import DatabaseService, get_database_service
 except Exception:  # pragma: no cover - fallback when asyncpg missing
@@ -174,7 +175,7 @@ class EvaluationPipeline:
         others = [a for a in advisors if a.id != "researcher"]
         selected_advisors = ([researcher] if researcher else []) + others[:1]
 
-        tasks: List[Task] = []
+        tasks: List[Task] = [build_skills_task(job)]
 
         def build_motivator_task(persona):
             async def _run() -> PersonaEvaluation:


### PR DESCRIPTION
## Summary
- add `build_skills_task` helper to wrap the skills agent as a pipeline task
- run skills analysis task as part of evaluation pipeline crew

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b73df9a8a883309e5944285415d952