### PR TITLE
Add compensation analysis to evaluation pipeline

### DIFF
--- a/python-service/app/models/evaluations.py
+++ b/python-service/app/models/evaluations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 
 
 class PersonaEvaluation(BaseModel):
@@ -32,3 +32,4 @@ class EvaluationSummary(BaseModel):
     job_id: str
     evaluations: List[PersonaEvaluation]
     decision: Optional[Decision] = None
+    analysis: Dict[str, Any] = Field(default_factory=dict)

--- a/python-service/app/services/crewai_job_review.py
+++ b/python-service/app/services/crewai_job_review.py
@@ -275,8 +275,22 @@ class CompensationAnalysisAgent:
         for benefit, patterns in benefit_patterns.items():
             if any(pattern in desc_lower for pattern in patterns):
                 found_benefits.append(benefit)
-        
+
         return found_benefits
+
+
+def build_compensation_task(job: Dict[str, Any]) -> "Task":
+    """Create a task that runs the CompensationAnalysisAgent."""
+    from .evaluation_pipeline import Task  # Local import to avoid circular dependency
+
+    async def _run() -> Dict[str, Any]:
+        analysis = CompensationAnalysisAgent().analyze(job)
+        return {
+            "salary_analysis": analysis["salary_analysis"],
+            "benefits_mentioned": analysis["benefits_mentioned"],
+        }
+
+    return Task(name="compensation_analysis", coro=_run)
 
 
 class QualityAssessmentAgent:


### PR DESCRIPTION
## Summary
- add compensation analysis task leveraging CompensationAnalysisAgent
- expose compensation and skills analyses through EvaluationPipeline summary
- extend EvaluationSummary model with analysis payload support

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b73f9e441883309dc06d099812a311