### PR TITLE
feat: externalize evaluation tasks to YAML

### DIFF
--- a/python-service/app/services/tasks.yaml
+++ b/python-service/app/services/tasks.yaml
@@ -1,0 +1,10 @@
+pre_tasks:
+  - id: skills_analysis
+    builder: build_skills_task
+    summary: Analyze job posting to extract required and preferred skills.
+  - id: compensation_analysis
+    builder: build_compensation_task
+    summary: Evaluate salary range and benefits.
+  - id: quality_assessment
+    builder: build_quality_task
+    summary: Determine job quality and potential red flags.


### PR DESCRIPTION
## Summary
- load analysis task builders from tasks.yaml
- add YAML config for skills, compensation, and quality tasks

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b73a844bd48330885644cbd0fd94cc