### PR TITLE
Pin httpx below 0.28 for ollama compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,14 +49,11 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
-    # Ensure llama3.3 model is pulled on startup
+    # Ensure llama3.3 model is available before serving
+    entrypoint: ["/bin/sh", "-c"]
     command: >
-      sh -c "
-      ollama serve &
-      sleep 10 &&
       ollama pull llama3.3 &&
-      wait
-      "
+      exec ollama serve
 
   # Defines the Redis cache service
   redis:

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -3,7 +3,8 @@ uvicorn[standard]==0.32.1
 pydantic==2.10.5
 python-multipart==0.0.17
 loguru==0.7.3
-httpx==0.28.1
+# Pin httpx below 0.28.0 for compatibility with ollama 0.4.5
+httpx==0.27.2
 python-json-logger==2.0.7
 # Load environment variables from .env files
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- pin httpx to 0.27.2 to avoid conflicts with ollama 0.4.5
- fix Ollama service startup script so the model pulls before serving

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `apt-get install -y docker.io docker-compose` *(fails: Unable to locate package docker.io)*
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b771bb80448330a30fc70dfc1b4412