### PR TITLE
Fix Ollama startup and pin httpx below 0.28

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   # Defines the Ollama service for local LLM inference
   ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.4.5
     container_name: trainium_ollama
     restart: always
     ports:
@@ -49,14 +49,18 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
-    # Ensure llama3.3 model is pulled on startup
-    command: >
-      sh -c "
-      ollama serve &
-      sleep 10 &&
-      ollama pull llama3.3 &&
-      wait
-      "
+    # Start server before pulling so the model downloads successfully
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+          ollama serve &
+          server_pid=$!
+          until curl -sf http://localhost:11434/api/tags >/dev/null; do
+            sleep 1
+          done
+          ollama pull llama3.3
+          wait $server_pid
 
   # Defines the Redis cache service
   redis:

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -3,7 +3,8 @@ uvicorn[standard]==0.32.1
 pydantic==2.10.5
 python-multipart==0.0.17
 loguru==0.7.3
-httpx==0.28.1
+# Restrict httpx below 0.28.0 for compatibility with ollama 0.4.5
+httpx<0.28.0
 python-json-logger==2.0.7
 # Load environment variables from .env files
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- start Ollama server before pulling llama3.3 model
- pin Ollama image to 0.4.5 and restrict httpx to <0.28.0 for compatibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y docker.io docker-compose` *(fails: Unable to locate package)*
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b771bb80448330a30fc70dfc1b4412