### PR TITLE
Add health checks and model configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,10 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 TAVILY_API_KEY=your_tavily_api_key
 
 # LLM Configuration
-LLM_PREFERENCE=ollama:llama3.3,openai:gpt-4o-mini,gemini:gemini-1.5-flash
+# Preferred model for Ollama
+LLM_MODEL=llama3.3
+# Compose will build preferences using LLM_MODEL
+LLM_PREFERENCE=ollama:${LLM_MODEL},openai:gpt-4o-mini,gemini:gemini-1.5-flash
 OLLAMA_HOST=http://ollama:11434
 OLLAMA_PORT=11434
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,16 @@ services:
       PGRST_DB_ANON_ROLE: ${POSTGRES_USER}
     depends_on:
       - db
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   # Defines the Ollama service for local LLM inference
   ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.4.5
     container_name: trainium_ollama
     restart: always
     ports:
@@ -44,19 +50,23 @@ services:
     environment:
       - OLLAMA_HOST=0.0.0.0
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      test: ["CMD", "ollama", "list"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 60s
-    # Ensure llama3.3 model is pulled on startup
-    command: >
-      sh -c "
-      ollama serve &
-      sleep 10 &&
-      ollama pull llama3.3 &&
-      wait
-      "
+    # Start server before pulling so the model downloads successfully
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+          ollama serve &
+          server_pid=$!
+          until ollama list >/dev/null 2>&1; do
+            sleep 1
+          done
+          ollama pull ${LLM_MODEL:-llama3.3}
+          wait $server_pid
 
   # Defines the Redis cache service
   redis:
@@ -67,6 +77,12 @@ services:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   # Defines the React front-end service
   frontend:
@@ -103,7 +119,7 @@ services:
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       TAVILY_API_KEY: ${TAVILY_API_KEY}
-      LLM_PREFERENCE: ${LLM_PREFERENCE:-ollama:llama3.3,openai:gpt-4o-mini,gemini:gemini-1.5-flash}
+      LLM_PREFERENCE: "ollama:${LLM_MODEL},openai:gpt-4o-mini,gemini:gemini-1.5-flash"
       OLLAMA_HOST: http://ollama:11434
       POSTGREST_URL: http://postgrest:3000
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
@@ -115,9 +131,12 @@ services:
       # Mount the python service code for development
       - ./python-service:/app
     depends_on:
-      - postgrest
-      - redis
-      - ollama
+      postgrest:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      ollama:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -141,7 +160,7 @@ services:
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       TAVILY_API_KEY: ${TAVILY_API_KEY}
-      LLM_PREFERENCE: ${LLM_PREFERENCE:-ollama:llama3.3,openai:gpt-4o-mini,gemini:gemini-1.5-flash}
+      LLM_PREFERENCE: "ollama:${LLM_MODEL},openai:gpt-4o-mini,gemini:gemini-1.5-flash"
       OLLAMA_HOST: http://ollama:11434
       POSTGREST_URL: http://postgrest:3000
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
@@ -150,8 +169,12 @@ services:
       REDIS_PORT: ${REDIS_PORT:-6379}
       REDIS_DB: ${REDIS_DB:-0}
     depends_on:
-      - python-service
-      - redis
+      postgrest:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      ollama:
+        condition: service_healthy
 
   # Defines the scheduler daemon using the python-service image
   scheduler:
@@ -169,7 +192,7 @@ services:
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       TAVILY_API_KEY: ${TAVILY_API_KEY}
-      LLM_PREFERENCE: ${LLM_PREFERENCE:-ollama:llama3.3,openai:gpt-4o-mini,gemini:gemini-1.5-flash}
+      LLM_PREFERENCE: "ollama:${LLM_MODEL},openai:gpt-4o-mini,gemini:gemini-1.5-flash"
       OLLAMA_HOST: http://ollama:11434
       POSTGREST_URL: http://postgrest:3000
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
@@ -178,8 +201,12 @@ services:
       REDIS_PORT: ${REDIS_PORT:-6379}
       REDIS_DB: ${REDIS_DB:-0}
     depends_on:
-      - python-service
-      - redis
+      postgrest:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      ollama:
+        condition: service_healthy
 
 volumes:
   # Defines the named volumes for data persistence.

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -3,7 +3,8 @@ uvicorn[standard]==0.32.1
 pydantic==2.10.5
 python-multipart==0.0.17
 loguru==0.7.3
-httpx==0.28.1
+# Pin httpx below 0.28.0 for compatibility with ollama 0.4.5
+httpx==0.27.2
 python-json-logger==2.0.7
 # Load environment variables from .env files
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- Parameterize Ollama model via new `LLM_MODEL` env and update services
- Replace curl-based Ollama readiness probe with `ollama list`
- Add health checks for PostgREST and Redis; gate python services on healthy deps
- Pin `httpx` to 0.27.2 for Ollama 0.4.5 compatibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b771bb80448330a30fc70dfc1b4412