### PR TITLE
Add dockerignore and simplify Dockerfile copying

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+node_modules
+logs
+*.log
+dist
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /app
 
 # Copy package.json and package-lock.json to the working directory
 COPY package*.json ./
-COPY package-lock.json ./
 
 # Install the project dependencies
 RUN npm install


### PR DESCRIPTION
## Summary
- ignore git, dependency, log, and build artifacts in Docker builds
- drop duplicate package-lock.json copy in Dockerfile

## Testing
- `npm run build`
- `docker compose build frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b783350cf08330a0521e09cb607516