### PR TITLE
Add PostgreSQL healthcheck and gate PostgREST startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,12 @@ services:
       - "${POSTGRES_PORT}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
 
   # Defines the PostgREST service to create a REST API for the database
   postgrest:
@@ -30,7 +36,8 @@ services:
       PGRST_DB_SCHEMA: public
       PGRST_DB_ANON_ROLE: ${POSTGRES_USER}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Add healthcheck to Postgres service using `pg_isready`
- Delay PostgREST startup until database reports healthy

## Testing
- `docker compose up -d db postgrest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b783405fd88330ac64e962b4374c3d