### PR TITLE
chore: trim docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,13 @@
 .git
 node_modules
-logs
-*.log
+npm-debug.log
+yarn-debug.log
+Dockerfile
+Dockerfile.dev
 dist
 build
+*.log
+*.tmp
+.env
+.env.local
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ FROM node:18-alpine
 WORKDIR /app
 
 # Copy package.json and package-lock.json to the working directory
-COPY package*.json ./
+COPY package.json package-lock.json ./
 
-# Install the project dependencies
-RUN npm install
+# Install the project dependencies using the lockfile for reproducible builds
+RUN npm ci
 
 # Copy the rest of the application's source code from the host to the container
 COPY . .


### PR DESCRIPTION
## Summary
- ignore repo metadata and build artifacts during Docker builds
- rely on package lock for reproducible frontend image builds

## Testing
- `npm run build`
- `docker compose build frontend` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b78044859c8330a5b2c61b42aba475