### PR TITLE
Ensure scheduler starts after frontend is healthy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ FROM node:18-alpine
 # Set the working directory in the container
 WORKDIR /app
 
+# Install curl for health checks
+RUN apk add --no-cache curl
+
 # Copy package.json and package-lock.json to the working directory
 COPY package.json package-lock.json ./
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,12 @@ services:
       # Mount the current directory ('.') which is the frontend source code
       - .:/app
       - /app/node_modules
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5173"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       - postgrest
       - python-service
@@ -143,6 +149,8 @@ services:
       redis:
         condition: service_healthy
       ollama:
+        condition: service_healthy
+      frontend:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
@@ -213,6 +221,8 @@ services:
       redis:
         condition: service_healthy
       ollama:
+        condition: service_healthy
+      frontend:
         condition: service_healthy
 
 volumes:


### PR DESCRIPTION
## Summary
- Install curl in the frontend image and add a container healthcheck
- Wait for the frontend before starting the Python service and scheduler

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b79e084b108330b90f02ee67fd2902