### PR TITLE
fix: remove docker compose circular dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,8 +150,6 @@ services:
         condition: service_healthy
       ollama:
         condition: service_healthy
-      frontend:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- remove frontend from python-service depends_on to break circular dependency

## Testing
- `docker compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ccf1e2ac8330b9c67005c557ddbc