### PR TITLE
Escape server_pid variable in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,12 +68,12 @@ services:
       - -c
       - |
           ollama serve &
-          server_pid=$!
+          server_pid=$$!
           until ollama list >/dev/null 2>&1; do
             sleep 1
           done
           ollama pull ${LLM_MODEL:-llama3.3}
-          wait $server_pid
+          wait $$server_pid
 
   # Defines the Redis cache service
   redis:


### PR DESCRIPTION
## Summary
- escape server_pid variable references in docker-compose to avoid Compose variable substitution warnings

## Testing
- `docker compose up --build` *(fails: command not found; Docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ce4c46348330be49884b99d280b9