### PR TITLE
chore: use internal db host in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,6 @@ REDIS_PORT=6379
 REDIS_DB=0
 
 # Database connection string  --UPDATE with values above
-DATABASE_URL=postgresql://trainium_user:changePGpassword@db:5434/trainium
+DATABASE_URL=postgresql://trainium_user:changePGpassword@db:5432/trainium
 POSTGREST_URL=http://postgrest:3000
 REDIS_URL=redis://redis:6379/0


### PR DESCRIPTION
## Summary
- point DATABASE_URL to internal `db` host on port 5432 so services share the same credentials

## Testing
- `npm run build`
- `docker compose up --build` *(fails: command not found; attempted `apt-get update` but repository access was forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d3d1714083309062e0f77ed08607