### PR TITLE
Fix NameError in skill categorization

### DIFF
--- a/python-service/app/services/crewai_job_review.py
+++ b/python-service/app/services/crewai_job_review.py
@@ -238,7 +238,7 @@ Be concise and focus on the most relevant skills mentioned.
             # Look for required indicators around the skill
             if any(req in desc_lower for req in [f'required {skill_lower}', f'{skill_lower} required', 'must have', 'essential']):
                 required_skills.append(skill)
-            elif any(pref in desc_lower for req in [f'preferred {skill_lower}', f'{skill_lower} preferred', 'nice to have', 'bonus']):
+            elif any(req in desc_lower for req in [f'preferred {skill_lower}', f'{skill_lower} preferred', 'nice to have', 'bonus']):
                 preferred_skills.append(skill)
             else:
                 # Default to required if not clearly categorized


### PR DESCRIPTION
## Summary
- fix typo in skill categorization loop causing NameError

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b8808e71288330afc7c3c1b6931ba4