### PR TITLE
Use LLM_PREFERENCE as fallback models

### DIFF
--- a/python-service/test_persona_loader.py
+++ b/python-service/test_persona_loader.py
@@ -1,0 +1,27 @@
+"""Tests for PersonaCatalog default model loading."""
+
+from app.services.persona_loader import PersonaCatalog
+
+
+def test_models_default_to_env_preference(tmp_path, monkeypatch):
+    """Personas without explicit models should use LLM_PREFERENCE order."""
+    catalog = tmp_path / "catalog.yaml"
+    catalog.write_text(
+        """
+        group1:
+          - id: test
+            role: tester
+        """
+    )
+
+    monkeypatch.setenv(
+        "LLM_PREFERENCE", "openai:gpt-4,gemini:gemini-1.5-flash"
+    )
+
+    loader = PersonaCatalog(catalog)
+
+    assert loader.get_models("test") == [
+        {"provider": "openai", "model": "gpt-4"},
+        {"provider": "gemini", "model": "gemini-1.5-flash"},
+    ]
+


### PR DESCRIPTION
## Summary
- Default persona `models` field to provider/model pairs from `LLM_PREFERENCE` when missing
- Parse `LLM_PREFERENCE` to build the fallback list
- Add unit test for environment-based default models

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: async plugin missing, database schema files absent, job persistence assertions, etc.)*
- `pytest python-service/test_persona_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68b88b3383588330a08f2b24ff0cd185