### PR TITLE
Refactor CrewAI job review to load YAML agents and tasks

### DIFF
--- a/LLM_MIGRATION.md
+++ b/LLM_MIGRATION.md
@@ -105,10 +105,10 @@ response = router.generate("Analyze this job posting...")
 
 ### CrewAI Enhanced Analysis
 ```python
-from app.services.crewai_job_review import get_crewai_job_review_service
+from app.services.crewai_job_review import get_job_review_crew
 
-service = get_crewai_job_review_service()
-analysis = await service.analyze_job(job_data)
+crew = get_job_review_crew().job_review()
+analysis = crew.kickoff(inputs={"job": job_data})
 
 # Analysis now includes:
 # - LLM-powered skills extraction

--- a/python-service/CREWAI_JOB_REVIEW.md
+++ b/python-service/CREWAI_JOB_REVIEW.md
@@ -269,10 +269,9 @@ ORDER BY created_at DESC
 
 ### Analyze a Single Job
 ```python
-from app.services.crewai_job_review import get_crewai_job_review_service
+from app.services.crewai_job_review import get_job_review_crew
 
-service = get_crewai_job_review_service()
-await service.initialize()
+crew = get_job_review_crew().job_review()
 
 job_data = {
     "title": "Software Engineer",
@@ -281,7 +280,7 @@ job_data = {
     # ... other fields
 }
 
-analysis = await service.analyze_job(job_data)
+analysis = crew.kickoff(inputs={"job": job_data})
 print(f"Recommendation: {analysis.overall_recommendation}")
 print(f"Quality Score: {analysis.job_quality_score}")
 ```

--- a/python-service/app/services/crewai_job_review.py
+++ b/python-service/app/services/crewai_job_review.py
@@ -6,56 +6,15 @@ specialized "agents" analyze various aspects of job postings to provide
 comprehensive insights and recommendations.
 """
 from typing import Dict, List, Any, Optional, Union
-from datetime import datetime, timezone
-import json
-import re
 from loguru import logger
-from dataclasses import dataclass, asdict
+from crewai import Crew, Process
+from crewai.crews import CrewBase, crew
 
-from ..core.config import get_settings
 from ..models.jobspy import ScrapedJob
-from .database import get_database_service
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .evaluation_pipeline import Task
-
-
-@dataclass
-class JobAnalysis:
-    """Result of job analysis by various agents."""
-    job_id: str
-    title: str
-    company: str
-    
-    # Skills and Requirements Analysis
-    required_skills: List[str]
-    preferred_skills: List[str]
-    experience_level: str
-    education_requirements: str
-    
-    # Compensation Analysis
-    salary_analysis: Dict[str, Any]
-    benefits_mentioned: List[str]
-    
-    # Quality and Fit Analysis
-    job_quality_score: float  # 0-100
-    description_completeness: float  # 0-100
-    red_flags: List[str]
-    green_flags: List[str]
-    
-    # Market and Company Analysis
-    company_insights: Dict[str, Any]
-    industry_category: str
-    remote_work_options: str
-    
-    # Overall Assessment
-    overall_recommendation: str
-    confidence_score: float  # 0-100
-    
-    # Metadata
-    analysis_timestamp: datetime
-    agents_used: List[str]
 
 
 class SkillsAnalysisAgent:
@@ -619,226 +578,30 @@ def build_quality_task(job: Dict[str, Any]) -> "Task":
     return Task(name="quality_assessment", coro=_run)
 
 
-class CrewAIJobReviewService:
-    """Main service orchestrating multiple agents for comprehensive job review."""
-    
-    def __init__(self):
-        self.settings = get_settings()
-        self.db_service = get_database_service()
-        
-        # Initialize LLM router for agent capabilities
-        from .llm_clients import LLMRouter
-        self.llm_router = LLMRouter(preferences=self.settings.llm_preference)
-        
-        # Initialize web search tool for agents
-        from .web_search import get_web_search_tool
-        self.web_search = get_web_search_tool()
-        
-        self.skills_agent = SkillsAnalysisAgent(self.llm_router, self.web_search)
-        self.compensation_agent = CompensationAnalysisAgent(self.llm_router, self.web_search)
-        self.quality_agent = QualityAssessmentAgent(self.llm_router, self.web_search)
-        self.initialized = False
-    
-    async def initialize(self) -> bool:
-        """Initialize the job review service."""
-        try:
-            if not self.db_service.initialized:
-                await self.db_service.initialize()
-            
-            self.initialized = True
-            logger.info("CrewAI Job Review Service initialized successfully")
-            return True
-        
-        except Exception as e:
-            logger.error(f"Failed to initialize CrewAI Job Review Service: {str(e)}")
-            return False
-    
-    async def analyze_job(self, job: Union[ScrapedJob, Dict[str, Any]], job_id: Optional[str] = None) -> JobAnalysis:
-        """
-        Perform comprehensive job analysis using multiple agents.
-        
-        Args:
-            job: ScrapedJob object or dictionary with job data
-            job_id: Optional job identifier
-            
-        Returns:
-            JobAnalysis object with comprehensive analysis results
-        """
-        if not self.initialized:
-            await self.initialize()
-        
-        logger.info(f"Starting comprehensive job analysis for job: {job_id}")
-        
-        # Extract basic job info
-        if isinstance(job, dict):
-            title = job.get('title', 'Unknown')
-            company = job.get('company', 'Unknown')
-        else:
-            title = job.title or 'Unknown'
-            company = job.company or 'Unknown'
-        
-        # Run agents in parallel conceptually (for now, sequentially)
-        skills_analysis = self.skills_agent.analyze(job)
-        compensation_analysis = self.compensation_agent.analyze(job)
-        quality_analysis = self.quality_agent.analyze(job)
-        
-        # Company and market analysis (simplified)
-        company_insights = self._analyze_company_and_market(job)
-        
-        # Calculate overall recommendation
-        overall_recommendation, confidence_score = self._calculate_overall_assessment(
-            skills_analysis, compensation_analysis, quality_analysis
+@CrewBase
+class JobReviewCrew:
+    """Crew configuration loading agents and tasks from YAML files."""
+
+    agents_config = "python-service/app/services/persona_catalog.yaml"
+    tasks_config = "python-service/app/services/tasks.yaml"
+
+    @crew
+    def job_review(self) -> Crew:
+        return Crew(
+            agents=self.agents,
+            tasks=self.tasks,
+            process=Process.sequential,
         )
-        
-        # Create analysis result
-        analysis = JobAnalysis(
-            job_id=job_id or f"job_{datetime.now().timestamp()}",
-            title=title,
-            company=company,
-            required_skills=skills_analysis['required_skills'],
-            preferred_skills=skills_analysis['preferred_skills'],
-            experience_level=skills_analysis['experience_level'],
-            education_requirements=skills_analysis['education_requirements'],
-            salary_analysis=compensation_analysis['salary_analysis'],
-            benefits_mentioned=compensation_analysis['benefits_mentioned'],
-            job_quality_score=quality_analysis['job_quality_score'],
-            description_completeness=quality_analysis['description_completeness'],
-            red_flags=quality_analysis['red_flags'],
-            green_flags=quality_analysis['green_flags'],
-            company_insights=company_insights,
-            industry_category=company_insights.get('industry', 'Unknown'),
-            remote_work_options=company_insights.get('remote_options', 'Not specified'),
-            overall_recommendation=overall_recommendation,
-            confidence_score=confidence_score,
-            analysis_timestamp=datetime.now(timezone.utc),
-            agents_used=['SkillsAnalysisAgent', 'CompensationAnalysisAgent', 'QualityAssessmentAgent']
-        )
-        
-        logger.info(f"Job analysis completed for {job_id}: {overall_recommendation} (confidence: {confidence_score:.1f}%)")
-        return analysis
-    
-    def _analyze_company_and_market(self, job: Union[ScrapedJob, Dict[str, Any]]) -> Dict[str, Any]:
-        """Analyze company and market context (simplified implementation)."""
-        description = job.get('description', '') if isinstance(job, dict) else (job.description or '')
-        location = job.get('location', '') if isinstance(job, dict) else (job.location or '')
-        is_remote = job.get('is_remote', False) if isinstance(job, dict) else (job.is_remote or False)
-        
-        # Simple industry categorization
-        industry = self._categorize_industry(description)
-        
-        # Remote work analysis
-        remote_options = 'Full Remote' if is_remote else self._analyze_remote_options(description)
-        
-        return {
-            'industry': industry,
-            'remote_options': remote_options,
-            'location': location
-        }
-    
-    def _categorize_industry(self, description: str) -> str:
-        """Simple industry categorization based on job description."""
-        desc_lower = description.lower()
-        
-        industry_keywords = {
-            'Technology': ['software', 'tech', 'developer', 'engineer', 'programming', 'coding'],
-            'Finance': ['finance', 'banking', 'investment', 'fintech', 'trading'],
-            'Healthcare': ['healthcare', 'medical', 'hospital', 'health', 'pharmaceutical'],
-            'Education': ['education', 'teaching', 'school', 'university', 'learning'],
-            'Marketing': ['marketing', 'advertising', 'brand', 'campaign', 'digital marketing'],
-            'Sales': ['sales', 'business development', 'account manager', 'revenue'],
-            'Consulting': ['consulting', 'consultant', 'advisory', 'strategy']
-        }
-        
-        for industry, keywords in industry_keywords.items():
-            if any(keyword in desc_lower for keyword in keywords):
-                return industry
-        
-        return 'Other'
-    
-    def _analyze_remote_options(self, description: str) -> str:
-        """Analyze remote work options from description."""
-        desc_lower = description.lower()
-        
-        if 'full remote' in desc_lower or 'fully remote' in desc_lower:
-            return 'Full Remote'
-        elif 'hybrid' in desc_lower or 'remote option' in desc_lower:
-            return 'Hybrid/Optional Remote'
-        elif 'on-site' in desc_lower or 'office' in desc_lower:
-            return 'On-site'
-        else:
-            return 'Not specified'
-    
-    def _calculate_overall_assessment(self, skills_analysis: Dict, compensation_analysis: Dict, quality_analysis: Dict) -> tuple:
-        """Calculate overall recommendation and confidence score."""
-        # Weight different factors
-        quality_score = quality_analysis['job_quality_score']
-        completeness_score = quality_analysis['description_completeness']
-        has_salary = compensation_analysis['salary_analysis'].get('has_salary_info', False)
-        red_flags_count = len(quality_analysis['red_flags'])
-        green_flags_count = len(quality_analysis['green_flags'])
-        
-        # Calculate weighted score
-        weighted_score = (
-            quality_score * 0.4 +
-            completeness_score * 0.3 +
-            (20 if has_salary else 0) * 0.1 +
-            max(0, (green_flags_count - red_flags_count)) * 5 * 0.2
-        )
-        
-        # Determine recommendation
-        if weighted_score >= 80 and red_flags_count == 0:
-            recommendation = 'Highly Recommended'
-        elif weighted_score >= 65 and red_flags_count <= 1:
-            recommendation = 'Recommended'
-        elif weighted_score >= 45:
-            recommendation = 'Consider with Caution'
-        else:
-            recommendation = 'Not Recommended'
-        
-        # Confidence based on data quality
-        confidence = min(95, max(20, weighted_score * 0.8 + (completeness_score * 0.2)))
-        
-        return recommendation, confidence
-    
-    async def analyze_multiple_jobs(self, jobs: List[Union[ScrapedJob, Dict[str, Any]]]) -> List[JobAnalysis]:
-        """Analyze multiple jobs and return sorted results."""
-        analyses = []
-        
-        for i, job in enumerate(jobs):
-            try:
-                job_id = f"batch_job_{i}"
-                analysis = await self.analyze_job(job, job_id)
-                analyses.append(analysis)
-            except Exception as e:
-                logger.error(f"Failed to analyze job {i}: {str(e)}")
-        
-        # Sort by overall recommendation quality
-        recommendation_order = {
-            'Highly Recommended': 4,
-            'Recommended': 3,
-            'Consider with Caution': 2,
-            'Not Recommended': 1
-        }
-        
-        analyses.sort(
-            key=lambda x: (recommendation_order.get(x.overall_recommendation, 0), x.confidence_score),
-            reverse=True
-        )
-        
-        return analyses
-    
-    def analysis_to_dict(self, analysis: JobAnalysis) -> Dict[str, Any]:
-        """Convert JobAnalysis to dictionary for API responses."""
-        return asdict(analysis)
 
 
-# Service singleton
-_job_review_service = None
+
+# Crew singleton
+_job_review_crew: Optional[JobReviewCrew] = None
 
 
-def get_crewai_job_review_service() -> CrewAIJobReviewService:
-    """Get the singleton CrewAI job review service instance."""
-    global _job_review_service
-    if _job_review_service is None:
-        _job_review_service = CrewAIJobReviewService()
-    return _job_review_service
+def get_job_review_crew() -> JobReviewCrew:
+    """Get the singleton JobReviewCrew instance."""
+    global _job_review_crew
+    if _job_review_crew is None:
+        _job_review_crew = JobReviewCrew()
+    return _job_review_crew

--- a/python-service/app/services/tasks.yaml
+++ b/python-service/app/services/tasks.yaml
@@ -1,19 +1,33 @@
 pre_tasks:
   - id: skills_analysis
     builder: build_skills_task
-    summary: Analyze job posting to extract required and preferred skills.
+    description: Analyze job posting to extract required and preferred skills along with experience and education insights.
+    expected_output: "{required_skills, preferred_skills, experience_level, education_requirements, all_technical_skills}"
+    context: "Raw job posting text and metadata"
+    async_execution: false
+    markdown: false
   - id: compensation_analysis
     builder: build_compensation_task
-    summary: Evaluate salary range and benefits.
+    description: Evaluate salary range, listed benefits, and any market insights.
+    expected_output: "{salary_analysis, benefits_mentioned}"
+    context: "Job salary information and description"
+    async_execution: false
+    markdown: false
   - id: quality_assessment
     builder: build_quality_task
-    summary: Determine job quality and potential red flags.
+    description: Determine job quality, completeness, and potential red or green flags.
+    expected_output: "{job_quality_score, description_completeness, red_flags, green_flags}"
+    context: "Job description, title, and company details"
+    async_execution: false
+    markdown: false
+
+persona_review_expected_output: &persona_review_output "{overall_recommendation, confidence_score, reasoning}"
 
 persona_review_tasks:
   - id: advisory_review
     agent: headhunter  # Example: can be any advisory persona
     description: "Analyze job opportunity from advisory perspective"
-    expected_output: "A structured evaluation with vote, confidence, and reasoning"
+    expected_output: *persona_review_output
     context: "Job posting data and user resume context"
     async_execution: false
     markdown: true
@@ -21,15 +35,15 @@ persona_review_tasks:
   - id: motivational_review
     agent: builder  # Example: can be any motivational persona
     description: "Evaluate job alignment with personal motivations and career goals"
-    expected_output: "Assessment of role fit with personal drivers and career trajectory"
+    expected_output: *persona_review_output
     context: "Job posting and motivational criteria"
     async_execution: false
     markdown: true
     
   - id: decision_review
-    agent: visionary  # Example: can be any decision persona  
+    agent: visionary  # Example: can be any decision persona
     description: "Make strategic decision on job opportunity"
-    expected_output: "Strategic decision with reasoning and confidence score"
+    expected_output: *persona_review_output
     context: "Job analysis results and previous persona evaluations"
     async_execution: false
     markdown: true
@@ -37,7 +51,7 @@ persona_review_tasks:
   - id: judge_synthesis
     agent: judge
     description: "Synthesize all evaluations into final recommendation"
-    expected_output: "Final verdict with comprehensive reasoning and trade-off analysis"
+    expected_output: *persona_review_output
     context: "All previous persona evaluations and job analysis"
     async_execution: false
     markdown: true

--- a/python-service/main.py
+++ b/python-service/main.py
@@ -18,7 +18,7 @@ from app.services.jobspy_ingestion import get_jobspy_service
 from app.services.database import get_database_service
 from app.services.queue import get_queue_service
 from app.services.scheduler import get_scheduler_service
-from app.services.crewai_job_review import get_crewai_job_review_service
+from app.services.crewai_job_review import get_job_review_crew
 from app.models.responses import create_error_response
 
 
@@ -43,7 +43,7 @@ async def lifespan(app: FastAPI):
     database_service = get_database_service()
     queue_service = get_queue_service()
     scheduler_service = get_scheduler_service()
-    crewai_review_service = get_crewai_job_review_service()
+    job_review_crew = get_job_review_crew()
     
     try:
         # Initialize existing services
@@ -55,7 +55,6 @@ async def lifespan(app: FastAPI):
         await database_service.initialize()
         await queue_service.initialize()
         await scheduler_service.initialize()
-        await crewai_review_service.initialize()
         
         logger.info("All services initialized successfully")
         


### PR DESCRIPTION
## Summary
- Replace legacy `CrewAIJobReviewService` with YAML-driven `JobReviewCrew`
- Update API and app startup to use crew singleton instead of service
- Refresh documentation for new crew usage
- Expand task configuration to mirror original job analysis steps
- Centralize JobAnalysis-style expected outputs for persona review tasks via YAML anchor

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b8980dddc883309c9962b5396b627b