### PR TITLE
Add CrewAI dependency for Python service

### DIFF
--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -32,5 +32,7 @@ googleapis-common-protos==1.63.2
 # LLM Provider clients
 ollama==0.4.5
 openai==1.58.1
+# Crew orchestration
+crewai==0.30.0
 # For web search tool
 tavily-python==0.5.0


### PR DESCRIPTION
## Summary
- include CrewAI library in Python service requirements for job-review features

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b8a795460483308063ab6d6665d55a