### PR TITLE
refactor: remove CrewBase from job review crew

### DIFF
--- a/python-service/app/services/crewai_job_review.py
+++ b/python-service/app/services/crewai_job_review.py
@@ -8,7 +8,7 @@ comprehensive insights and recommendations.
 from typing import Dict, List, Any, Optional, Union
 from pathlib import Path
 from loguru import logger
-from crewai import Crew, Process, CrewBase, crew
+from crewai import Crew, Process, crew
 
 from ..models.jobspy import ScrapedJob
 from typing import TYPE_CHECKING
@@ -578,7 +578,6 @@ def build_quality_task(job: Dict[str, Any]) -> "Task":
     return Task(name="quality_assessment", coro=_run)
 
 
-@CrewBase
 class JobReviewCrew:
     """Crew configuration loading agents and tasks from YAML files."""
     _base_dir = Path(__file__).resolve().parent


### PR DESCRIPTION
## Summary
- drop CrewBase decorator and import in job review service
- ensure job_review still constructs a sequential Crew

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b8c11471348330ad1ffe7bd19695c8