### PR TITLE
fix: update crewai job review import path

### DIFF
--- a/python-service/main.py
+++ b/python-service/main.py
@@ -18,7 +18,7 @@ from app.services.jobspy_ingestion import get_jobspy_service
 from app.services.database import get_database_service
 from app.services.queue import get_queue_service
 from app.services.scheduler import get_scheduler_service
-from app.services.crewai_job_review import get_job_review_crew
+from app.services.crewai import get_job_review_crew
 from app.models.responses import create_error_response
 
 


### PR DESCRIPTION
## Summary
- refactor main service to import get_job_review_crew from app.services.crewai

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service` *(fails: DATABASE_URL is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e982c6ec8330aeca0c9f6dff90c5