### PR TITLE
Cast Decimal salary fields to floats in DB job review

### DIFF
--- a/python-service/app/api/crewai_review.py
+++ b/python-service/app/api/crewai_review.py
@@ -3,6 +3,7 @@ API endpoints for CrewAI job review functionality.
 """
 from typing import List, Dict, Any, Optional
 from datetime import datetime
+from decimal import Decimal
 from pathlib import Path
 import yaml
 from fastapi import APIRouter, HTTPException, Query
@@ -160,6 +161,7 @@ async def review_jobs_from_database(
                 "site": row["site"],
                 "job_url": row["job_url"]
             }
+            job_data = {k: (float(v) if isinstance(v, Decimal) else v) for k, v in job_data.items()}
             jobs_data.append(job_data)
 
         analyses = [review_crew.job_review().kickoff(inputs={"job": job}) for job in jobs_data]


### PR DESCRIPTION
## Summary
- Convert Decimal values from the database to floats in `/jobs/review/from-db` to avoid serialization errors.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uvicorn main:app --host 0.0.0.0 --port 8000` and `curl -s -X GET 'http://localhost:8000/jobs/review/from-db'` *(fails: Database connection pool is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ee14af588330916ba9a3deac3d0f