### PR TITLE
feat: route job review agents through LLM router

### DIFF
--- a/python-service/app/services/crewai/job_review/crew.py
+++ b/python-service/app/services/crewai/job_review/crew.py
@@ -5,14 +5,17 @@ This crew implements a comprehensive job review system using specialized agents
 to analyze different aspects of job postings including skills, compensation, 
 and quality assessment.
 """
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Tuple
 from pathlib import Path
 from loguru import logger
 
 from crewai import Agent, Crew, Task, Process
 from crewai.project import CrewBase, agent, task, crew, before_kickoff, after_kickoff
+from crewai.llm import BaseLLM
 
 from .. import base
+from ...llm_clients import LLMRouter
+from ....core.config import get_settings
 from ....models.jobspy import ScrapedJob
 
 
@@ -31,6 +34,67 @@ class JobReviewCrew:
         """Initialize the JobReviewCrew with YAML configurations."""
         self.base_dir = Path(__file__).resolve().parent.parent
         self.crew_name = "job_review"
+        settings = get_settings()
+        self._router = LLMRouter(preferences=settings.llm_preference)
+        self._agent_llms: Dict[str, BaseLLM] = {}
+
+    def _parse_model_config(self, models: List[Dict[str, Any]] | None) -> List[Tuple[str, str]]:
+        """Convert agent model configs to provider/model tuples."""
+        if not models:
+            return []
+        prefs: List[Tuple[str, str]] = []
+        for entry in models:
+            provider = entry.get("provider")
+            model = entry.get("model")
+            if not provider or not model:
+                continue
+            provider = provider.lower()
+            if provider == "google":
+                provider = "gemini"
+            prefs.append((provider, model))
+        return prefs
+
+    class _RouterLLM(BaseLLM):
+        """Adapter to use LLMRouter with CrewAI agents."""
+
+        def __init__(self, router: LLMRouter, preferences: List[Tuple[str, str]] | None = None):
+            model_name = preferences[0][1] if preferences else "router"
+            super().__init__(model=model_name)
+            self._router = router
+            self._preferences = preferences or []
+
+        def call(
+            self,
+            messages: Any,
+            tools: Optional[List[dict]] = None,
+            callbacks: Optional[List[Any]] = None,
+            available_functions: Optional[Dict[str, Any]] = None,
+            from_task: Optional[Any] = None,
+            from_agent: Optional[Any] = None,
+        ) -> str:
+            if isinstance(messages, list):
+                prompt = "\n".join(m.get("content", "") for m in messages if isinstance(m, dict))
+            else:
+                prompt = str(messages)
+
+            if self._preferences:
+                original = list(self._router.providers)
+                try:
+                    ordered = self._preferences + [p for p in original if p not in self._preferences]
+                    self._router.providers = ordered
+                    return self._router.generate(prompt)
+                finally:
+                    self._router.providers = original
+            return self._router.generate(prompt)
+
+    def _get_agent_llm(self, agent_name: str, config: Dict[str, Any]) -> BaseLLM:
+        """Get or create RouterLLM for an agent."""
+        if agent_name in self._agent_llms:
+            return self._agent_llms[agent_name]
+        prefs = self._parse_model_config(config.get("models"))
+        llm = self._RouterLLM(self._router, prefs if prefs else None)
+        self._agent_llms[agent_name] = llm
+        return llm
         
     @agent
     def researcher_agent(self) -> Agent:
@@ -45,6 +109,7 @@ class JobReviewCrew:
             role=config["role"],
             goal=config["goal"],
             backstory=config["backstory"],
+            llm=self._get_agent_llm("researcher", config),
             max_iter=config.get("max_iter", 2),
             max_execution_time=config.get("max_execution_time", 60),
             tools=config.get("tools", []),
@@ -64,6 +129,7 @@ class JobReviewCrew:
             role=config["role"],
             goal=config["goal"],
             backstory=config["backstory"],
+            llm=self._get_agent_llm("negotiator", config),
             max_iter=config.get("max_iter", 2),
             max_execution_time=config.get("max_execution_time", 60),
             tools=config.get("tools", []),
@@ -83,6 +149,7 @@ class JobReviewCrew:
             role=config["role"],
             goal=config["goal"],
             backstory=config["backstory"],
+            llm=self._get_agent_llm("skeptic", config),
             max_iter=config.get("max_iter", 2),
             max_execution_time=config.get("max_execution_time", 60),
             tools=config.get("tools", []),


### PR DESCRIPTION
## Summary
- route job review crew agents through a shared LLMRouter honoring Settings.llm_preference
- parse agent model config to prefer specific provider/model pairs
- use router-backed LLMs for researcher, negotiator, and skeptic agents

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python` manual test invoking `/jobs/review/from-db` (stub DB & LLM) -> provider gemini used, analysis returned
- `pytest python-service/test_llm_router.py` *(fails: KeyboardInterrupt during plugin load)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f8cb9a388330a1d0c1b230de661c