### PR TITLE
Use pg_search_tool in branding agent

### DIFF
--- a/python-service/app/services/crewai/personal_branding/crew.py
+++ b/python-service/app/services/crewai/personal_branding/crew.py
@@ -7,7 +7,6 @@ from loguru import logger
 
 from crewai import Agent, Crew, Task, Process
 from crewai.project import CrewBase, agent, task, crew, before_kickoff, after_kickoff
-from crewai_tools import PGSearchTool
 from crewai.llm import BaseLLM
 
 from .. import base
@@ -102,6 +101,7 @@ class PersonalBrandCrew:
             role=config["role"],
             goal=config["goal"],
             backstory=config["backstory"],
+            tools=[pg_search_tool()],
             llm=self._get_agent_llm("branding_agent", config),
             max_iter=config.get("max_iter", 2),
             max_execution_time=config.get("max_execution_time", 60),


### PR DESCRIPTION
## Summary
- call `pg_search_tool()` when creating the branding agent to supply the PG search capability
- ensure configs still reference `pg_search_tool`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ba6e659bdc8330b0668a1ca576edad