### PR TITLE
Filter PGSearchTool by narrative name

### DIFF
--- a/python-service/app/services/crewai/personal_branding/crew.py
+++ b/python-service/app/services/crewai/personal_branding/crew.py
@@ -116,12 +116,20 @@ class PersonalBrandCrew:
         """
         config = self.tasks_config["personal_branding_review"]
         agent_method = getattr(self, config["agent"])
-        return Task(
+
+        task = Task(
             description=config["description"],
             expected_output=config["expected_output"],
             agent=agent_method(),
-            async_execution=False
+            async_execution=False,
+            metadata=config.get("metadata", {}),
         )
+
+        narrative_name = task.metadata.get("narrative_name") if task.metadata else None
+        if narrative_name:
+            task.agent.tools = [pg_search_tool(narrative_name)]
+
+        return task
 
     @crew
     def branding_crew(self) -> Crew:

--- a/python-service/app/services/crewai/tools/pg_search.py
+++ b/python-service/app/services/crewai/tools/pg_search.py
@@ -1,11 +1,24 @@
 import os
+from typing import Optional, Dict
 from crewai_tools import PGSearchTool
 
 
-def pg_search_tool():
+def pg_search_tool(narrative_name: Optional[str] = None) -> PGSearchTool:
+    """Create a PGSearchTool configured for strategic narratives.
+
+    Args:
+        narrative_name: Optional narrative name to filter search results.
+
+    Returns:
+        Configured PGSearchTool instance.
+    """
+    filters: Optional[Dict[str, str]] = None
+    if narrative_name:
+        filters = {"narrative_name": narrative_name}
     return PGSearchTool(
         db_url=os.getenv("DATABASE_URL"),
         table_name="strategic_narratives",
         content_column="narrative_text",
         metadata_columns=["narrative_name"],
+        filters=filters,
     )


### PR DESCRIPTION
## Summary
- Pass narrative_name from task metadata to PGSearchTool in personal branding review
- Support narrative_name filter in PGSearchTool helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `DATABASE_URL=sqlite:// pytest` *(fails: async plugin missing, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6feea6f083309d16511886d02898