### PR TITLE
Use async kickoff for personal branding API

### DIFF
--- a/python-service/app/api/crewai_personal_brand.py
+++ b/python-service/app/api/crewai_personal_brand.py
@@ -4,8 +4,10 @@ from ..services.crewai import get_personal_brand_crew
 
 router = APIRouter(tags=["Personal Branding"])
 
+
 @router.post("/personal-brand")
 async def personal_branding():
-    crew = get_personal_brand_crew()
-    result = crew.kickoff(inputs={"Job": "Product Manager"})
+    crew = get_personal_brand_crew().crew()
+    result = await crew.kickoff(inputs={"Job": "Product Manager"})
     return {"personal_branding_document": result}
+


### PR DESCRIPTION
## Summary
- Switch personal branding endpoint to use the personal brand crew's async kickoff

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service` *(fails: DATABASE_URL is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ba98eac2008330acc252d350f37b62