### PR TITLE
Fix personal branding endpoint awaiting non-awaitable result

### DIFF
--- a/python-service/app/api/crewai_personal_brand.py
+++ b/python-service/app/api/crewai_personal_brand.py
@@ -8,6 +8,6 @@ router = APIRouter(tags=["Personal Branding"])
 @router.post("/personal-brand")
 async def personal_branding():
     crew = get_personal_brand_crew().crew()
-    result = await crew.kickoff(inputs={"Job": "Product Manager"})
-    return {"personal_branding_document": result}
+    result = crew.kickoff(inputs={"Job": "Product Manager"})
+    return {"personal_branding_document": result.raw}
 


### PR DESCRIPTION
## Summary
- Remove `await` from `crew.kickoff` call in personal branding API
- Return the crew output's raw text so FastAPI can serialize the response

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service -q` *(fails: DATABASE_URL is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2bab6b608330a4acf44b7d2d38f9