### PR TITLE
Refactor service initialization to use app.state

### DIFF
--- a/python-service/app/api/v1/endpoints/crewai_review.py
+++ b/python-service/app/api/v1/endpoints/crewai_review.py
@@ -9,10 +9,14 @@ import yaml
 from fastapi import APIRouter, HTTPException, Query, Depends
 from loguru import logger
 
-from app.schemas.responses import StandardResponse, create_success_response, create_error_response
-from app.dependencies import get_job_review_crew, get_database_service
-from app.services.crewai import JobReviewCrew
-from app.services.infrastructure.database import DatabaseService
+from ....schemas.responses import (
+    StandardResponse,
+    create_success_response,
+    create_error_response,
+)
+from ....dependencies import get_job_review_crew, get_database_service
+from ....services.crewai import JobReviewCrew
+from ....services.infrastructure.database import DatabaseService
 
 router = APIRouter(prefix="/jobs", tags=["Job Review"])
 

--- a/python-service/app/api/v1/endpoints/crewai_review.py
+++ b/python-service/app/api/v1/endpoints/crewai_review.py
@@ -6,18 +6,22 @@ from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
 import yaml
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from loguru import logger
 
 from app.schemas.responses import StandardResponse, create_success_response, create_error_response
-from app.services.crewai import get_job_review_crew
-from app.services.infrastructure.database import get_database_service
+from app.dependencies import get_job_review_crew, get_database_service
+from app.services.crewai import JobReviewCrew
+from app.services.infrastructure.database import DatabaseService
 
 router = APIRouter(prefix="/jobs", tags=["Job Review"])
 
 
 @router.post("/review", response_model=StandardResponse)
-async def review_single_job(job_data: Dict[str, Any]):
+async def review_single_job(
+    job_data: Dict[str, Any],
+    job_review_crew: JobReviewCrew = Depends(get_job_review_crew),
+):
     """
     Analyze a single job using CrewAI multi-agent review system.
     
@@ -28,7 +32,7 @@ async def review_single_job(job_data: Dict[str, Any]):
         Comprehensive job analysis with recommendations
     """
     try:
-        crew = get_job_review_crew().job_review()
+        crew = job_review_crew.job_review()
         analysis = crew.kickoff(inputs={"job": job_data})
 
         return create_success_response(
@@ -45,7 +49,10 @@ async def review_single_job(job_data: Dict[str, Any]):
 
 
 @router.post("/review/batch", response_model=StandardResponse)
-async def review_multiple_jobs(jobs_data: List[Dict[str, Any]]):
+async def review_multiple_jobs(
+    jobs_data: List[Dict[str, Any]],
+    job_review_crew: JobReviewCrew = Depends(get_job_review_crew),
+):
     """
     Analyze multiple jobs using CrewAI multi-agent review system.
     
@@ -62,7 +69,7 @@ async def review_multiple_jobs(jobs_data: List[Dict[str, Any]]):
                 detail="Cannot analyze more than 50 jobs at once"
             )
         
-        review_crew = get_job_review_crew()
+        review_crew = job_review_crew
 
         analyses = []
         for job in jobs_data:
@@ -87,7 +94,9 @@ async def review_jobs_from_database(
     limit: int = Query(10, ge=1, le=50, description="Number of jobs to analyze"),
     site: Optional[str] = Query(None, description="Filter by job site"),
     company: Optional[str] = Query(None, description="Filter by company name"),
-    title_contains: Optional[str] = Query(None, description="Filter jobs with title containing this text")
+    title_contains: Optional[str] = Query(None, description="Filter jobs with title containing this text"),
+    job_review_crew: JobReviewCrew = Depends(get_job_review_crew),
+    db_service: DatabaseService = Depends(get_database_service),
 ):
     """
     Analyze jobs from the database using CrewAI multi-agent review system.
@@ -102,8 +111,7 @@ async def review_jobs_from_database(
         Job analyses with database job IDs
     """
     try:
-        review_crew = get_job_review_crew()
-        db_service = get_database_service()
+        review_crew = job_review_crew
 
         if not db_service.initialized:
             await db_service.initialize()

--- a/python-service/app/api/v1/endpoints/jobspy.py
+++ b/python-service/app/api/v1/endpoints/jobspy.py
@@ -6,18 +6,22 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query, Depends
 from loguru import logger
 
-from app.schemas.responses import StandardResponse, create_success_response, create_error_response
-from app.schemas.jobspy import JobSearchRequest
-from app.dependencies import (
+from ....schemas.responses import (
+    StandardResponse,
+    create_success_response,
+    create_error_response,
+)
+from ....schemas.jobspy import JobSearchRequest
+from ....dependencies import (
     get_jobspy_service,
     get_queue_service,
     get_database_service,
 )
-from app.services.jobspy.ingestion import JobSpyIngestionService
-from app.services.infrastructure.queue import QueueService
-from app.services.infrastructure.database import DatabaseService
-from app.services.jobspy.scraping import scrape_jobs_async
-from app.services.infrastructure.job_persistence import persist_jobs
+from ....services.jobspy.ingestion import JobSpyIngestionService
+from ....services.infrastructure.queue import QueueService
+from ....services.infrastructure.database import DatabaseService
+from ....services.jobspy.scraping import scrape_jobs_async
+from ....services.infrastructure.job_persistence import persist_jobs
 
 router = APIRouter()
 
@@ -292,7 +296,7 @@ async def jobspy_health_check(
             }
         }
         
-        from app.schemas.responses import create_success_response
+        from ....schemas.responses import create_success_response
         return create_success_response(
             data=health_data,
             message="JobSpy service health check completed"

--- a/python-service/app/api/v1/endpoints/scheduler.py
+++ b/python-service/app/api/v1/endpoints/scheduler.py
@@ -4,9 +4,9 @@ Scheduler API endpoints for managing job scraping schedules.
 from fastapi import APIRouter, HTTPException, Depends
 from loguru import logger
 
-from app.schemas.responses import StandardResponse, create_success_response
-from app.dependencies import get_scheduler_service
-from app.services.infrastructure.scheduler import SchedulerService
+from ....schemas.responses import StandardResponse, create_success_response
+from ....dependencies import get_scheduler_service
+from ....services.infrastructure.scheduler import SchedulerService
 
 router = APIRouter()
 

--- a/python-service/app/dependencies.py
+++ b/python-service/app/dependencies.py
@@ -1,12 +1,12 @@
 from fastapi import Request
 
-from app.services.ai.gemini import GeminiService
-from app.services.infrastructure.postgrest import PostgRESTService
-from app.services.jobspy.ingestion import JobSpyIngestionService
-from app.services.infrastructure.database import DatabaseService
-from app.services.infrastructure.queue import QueueService
-from app.services.infrastructure.scheduler import SchedulerService
-from app.services.crewai import JobReviewCrew
+from .services.ai.gemini import GeminiService
+from .services.infrastructure.postgrest import PostgRESTService
+from .services.jobspy.ingestion import JobSpyIngestionService
+from .services.infrastructure.database import DatabaseService
+from .services.infrastructure.queue import QueueService
+from .services.infrastructure.scheduler import SchedulerService
+from .services.crewai import JobReviewCrew
 
 
 def get_gemini_service(request: Request) -> GeminiService:

--- a/python-service/app/dependencies.py
+++ b/python-service/app/dependencies.py
@@ -1,0 +1,45 @@
+from fastapi import Request
+
+from app.services.ai.gemini import GeminiService
+from app.services.infrastructure.postgrest import PostgRESTService
+from app.services.jobspy.ingestion import JobSpyIngestionService
+from app.services.infrastructure.database import DatabaseService
+from app.services.infrastructure.queue import QueueService
+from app.services.infrastructure.scheduler import SchedulerService
+from app.services.crewai import JobReviewCrew
+
+
+def get_gemini_service(request: Request) -> GeminiService:
+    """Retrieve the Gemini service instance from application state."""
+    return request.app.state.gemini_service
+
+
+def get_postgrest_service(request: Request) -> PostgRESTService:
+    """Retrieve the PostgREST service instance from application state."""
+    return request.app.state.postgrest_service
+
+
+def get_jobspy_service(request: Request) -> JobSpyIngestionService:
+    """Retrieve the JobSpy ingestion service instance from application state."""
+    return request.app.state.jobspy_service
+
+
+def get_database_service(request: Request) -> DatabaseService:
+    """Retrieve the database service instance from application state."""
+    return request.app.state.database_service
+
+
+def get_queue_service(request: Request) -> QueueService:
+    """Retrieve the queue service instance from application state."""
+    return request.app.state.queue_service
+
+
+def get_scheduler_service(request: Request) -> SchedulerService:
+    """Retrieve the scheduler service instance from application state."""
+    return request.app.state.scheduler_service
+
+
+def get_job_review_crew(request: Request) -> JobReviewCrew:
+    """Retrieve the JobReviewCrew instance from application state."""
+    return request.app.state.job_review_crew
+


### PR DESCRIPTION
## Summary
- Instantiate core services during app lifespan and store them on `app.state`
- Expose service instances via dependency getters for FastAPI `Depends`
- Inject services into JobSpy, scheduler, and CrewAI review endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bb6b86e51083309b58d9fdf7d7ae67