### PR TITLE
refactor: inject services with FastAPI Depends using relative imports

### DIFF
--- a/python-service/app/api/v1/endpoints/crewai_personal_brand.py
+++ b/python-service/app/api/v1/endpoints/crewai_personal_brand.py
@@ -1,13 +1,15 @@
-from fastapi import APIRouter
-from app.services.crewai import get_personal_brand_crew
+from fastapi import APIRouter, Depends
+from ....services.crewai import PersonalBrandCrew, get_personal_brand_crew
 
 
 router = APIRouter(tags=["Personal Branding"])
 
 
 @router.post("/personal-brand")
-async def personal_branding():
-    crew = get_personal_brand_crew().crew()
+async def personal_branding(
+    personal_brand_crew: PersonalBrandCrew = Depends(get_personal_brand_crew),
+):
+    crew = personal_brand_crew.crew()
     result = crew.kickoff(inputs={"Job": "Product Manager"})
     return {"personal_branding_document": result.raw}
 

--- a/python-service/app/api/v1/endpoints/crewai_review.py
+++ b/python-service/app/api/v1/endpoints/crewai_review.py
@@ -246,15 +246,17 @@ async def get_available_agents():
         )
 
 @router.get("/review/health", response_model=StandardResponse)
-async def health_check():
+async def health_check(
+    job_review_crew: JobReviewCrew = Depends(get_job_review_crew),
+):
     """
     Health check for the CrewAI job review service.
-    
+
     Returns:
         Service health status and initialization state
     """
     try:
-        crew = get_job_review_crew()
+        crew = job_review_crew
 
         health_status = {
             "service": "JobReviewCrew",

--- a/python-service/app/api/v1/endpoints/health.py
+++ b/python-service/app/api/v1/endpoints/health.py
@@ -5,14 +5,14 @@ from datetime import datetime
 from fastapi import APIRouter
 from loguru import logger
 
-from app.schemas.responses import StandardResponse, HealthStatus, create_success_response
-from app.core.config import get_settings
+from ....schemas.responses import StandardResponse, HealthStatus, create_success_response
+from ....core.config import get_settings
 
 
 def _get_llm_provider_status():
     """Get status of available LLM providers."""
     try:
-        from app.services.ai.llm_clients import LLMRouter
+        from ....services.ai.llm_clients import LLMRouter
         settings = get_settings()
         router = LLMRouter(preferences=settings.llm_preference)
         return [

--- a/python-service/app/api/v1/endpoints/jobspy.py
+++ b/python-service/app/api/v1/endpoints/jobspy.py
@@ -296,7 +296,6 @@ async def jobspy_health_check(
             }
         }
         
-        from ....schemas.responses import create_success_response
         return create_success_response(
             data=health_data,
             message="JobSpy service health check completed"


### PR DESCRIPTION
## Summary
- inject `PersonalBrandCrew` in personal branding endpoint with FastAPI `Depends`
- inject `JobReviewCrew` in CrewAI review health check endpoint
- switch API endpoints to package-relative imports for Docker portability

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bb6f8027988330959267dd0448095c