### PR TITLE
Refactor tests to use explicit services and shared fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,25 @@
 import os
+from unittest.mock import Mock
+
+import pytest
 
 # Ensure required environment variables are present for tests
 os.environ.setdefault("DATABASE_URL", "postgresql://fake:fake@localhost:5432/fake")
+
+
+@pytest.fixture
+def mock_db_service():
+    """Return a database service mock with initialization flagged."""
+    service = Mock()
+    service.initialized = True
+    return service
+
+
+@pytest.fixture
+def job_persistence_service(mock_db_service):
+    """Provide a JobPersistenceService with its database dependency mocked."""
+    from app.services.infrastructure.job_persistence import JobPersistenceService
+
+    service = JobPersistenceService()
+    service.db_service = mock_db_service
+    return service

--- a/tests/services/test_persistence_unit.py
+++ b/tests/services/test_persistence_unit.py
@@ -1,22 +1,7 @@
 """Simple tests for job persistence functionality without database dependencies."""
 from datetime import datetime
-from unittest.mock import Mock, patch
 
 from app.schemas.jobspy import ScrapedJob
-
-
-def _create_service():
-    """Create JobPersistenceService with a mocked database service."""
-    mock_db_service = Mock()
-    mock_db_service.initialized = True
-    with patch(
-        "app.services.infrastructure.job_persistence.get_database_service",
-        return_value=mock_db_service,
-    ):
-        from app.services.infrastructure.job_persistence import JobPersistenceService
-
-        service = JobPersistenceService()
-    return service
 
 
 def test_scraped_job_model():
@@ -48,9 +33,9 @@ def test_scraped_job_model():
     assert job.emails == ["hr@company.com"]
 
 
-def test_job_field_mapping_logic():
+def test_job_field_mapping_logic(job_persistence_service):
     """Test the field mapping logic without database calls."""
-    service = _create_service()
+    service = job_persistence_service
 
     test_job = ScrapedJob(
         title="Data Scientist",
@@ -93,9 +78,9 @@ def test_job_field_mapping_logic():
     assert "scraped_at" in mapped["source_raw"]
 
 
-def test_date_parsing():
+def test_date_parsing(job_persistence_service):
     """Test date parsing functionality."""
-    service = _create_service()
+    service = job_persistence_service
 
     test_cases = [
         ("2025-01-24", True),


### PR DESCRIPTION
## Summary
- replace service getter patches with direct `JobPersistenceService` instances
- provide reusable database and persistence service fixtures for tests
- update tests to assert behavior through these explicit services

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/services/test_persistence_unit.py tests/integration/test_workflow_demo.py tests/integration/test_integration_persistence.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb7b9c89c08330aa3cdbe506fe2987