### PR TITLE
Add ChromaDB client and configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ LLM_PREFERENCE=ollama:${LLM_MODEL},openai:gpt-4o-mini,gemini:gemini-1.5-flash
 OLLAMA_HOST=http://ollama:11434
 OLLAMA_PORT=11434
 
+# ChromaDB configuration
+CHROMA_URL=chromadb
+CHROMA_PORT=8000
+
 # Redis configuration
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/python-service/app/core/config.py
+++ b/python-service/app/core/config.py
@@ -41,6 +41,10 @@ class Settings:
         )
         self.ollama_host: str = os.getenv("OLLAMA_HOST", "http://localhost:11434")
 
+        # ChromaDB Configuration
+        self.chroma_url: str = os.getenv("CHROMA_URL", "chromadb")
+        self.chroma_port: int = int(os.getenv("CHROMA_PORT", "8000"))
+
         # PostgREST Configuration (for future integration)
         self.postgrest_url: str = os.getenv("POSTGREST_URL", "http://postgrest:3000")
 

--- a/python-service/app/services/infrastructure/__init__.py
+++ b/python-service/app/services/infrastructure/__init__.py
@@ -10,6 +10,7 @@ from .job_persistence import (
     get_job_persistence_service,
     persist_jobs,
 )
+from .chroma import get_chroma_client
 
 __all__ = [
     "DatabaseService",
@@ -26,4 +27,5 @@ __all__ = [
     "JobPersistenceService",
     "get_job_persistence_service",
     "persist_jobs",
+    "get_chroma_client",
 ]

--- a/python-service/app/services/infrastructure/chroma.py
+++ b/python-service/app/services/infrastructure/chroma.py
@@ -1,0 +1,11 @@
+"""ChromaDB client initialization."""
+
+import chromadb
+
+from ...core.config import get_settings
+
+
+def get_chroma_client() -> chromadb.HttpClient:
+    """Create and return a ChromaDB HTTP client using configured settings."""
+    settings = get_settings()
+    return chromadb.HttpClient(host=settings.chroma_url, port=settings.chroma_port)

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -42,4 +42,7 @@ tavily-python==0.7.11
 asyncpg==0.30.0
 psycopg[binary]==3.2.9
 
+# Vector database client
+chromadb
+
 


### PR DESCRIPTION
## Summary
- configure ChromaDB client helper and expose it via infrastructure package
- add CHROMA_URL and CHROMA_PORT settings with example env values
- include chromadb package in Python service requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bddaedf85483308e77fd6d335ace6a