### PR TITLE
feat: customize ChromaDB container with curl

### DIFF
--- a/Dockerfile.chromadb
+++ b/Dockerfile.chromadb
@@ -1,0 +1,2 @@
+FROM chromadb/chroma:latest
+RUN apt-get update && apt-get install -y curl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,9 @@ services:
 
   # Defines the ChromaDB vector database service
   chromadb:
-    image: chromadb/chroma:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.chromadb
     container_name: trainium_chromadb
     restart: always
     ports:


### PR DESCRIPTION
## Summary
- add Dockerfile.chromadb based on chromadb/chroma:latest and install curl
- update docker-compose chromadb service to build from Dockerfile.chromadb and retain healthcheck

## Testing
- `docker compose up --build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be88b0dbe08330968671cef3460c56