### PR TITLE
fix chroma service client import

### DIFF
--- a/python-service/app/services/chroma_service.py
+++ b/python-service/app/services/chroma_service.py
@@ -7,7 +7,7 @@ from typing import List, Tuple
 from loguru import logger
 from chromadb.utils import embedding_functions
 
-from ..infrastructure.chroma import get_chroma_client
+from .infrastructure import get_chroma_client
 from ..schemas.chroma import ChromaUploadRequest, ChromaUploadResponse, ChromaCollectionInfo
 
 


### PR DESCRIPTION
## Summary
- fix relative import for Chroma client in service

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/tests/services/test_chroma_service.py` *(fails: ModuleNotFoundError: sentence_transformers)*


------
https://chatgpt.com/codex/tasks/task_e_68be96a8d2988330b2f67df31a04cb13