### PR TITLE
Serialize tags metadata for Chroma uploads

### DIFF
--- a/python-service/app/services/chroma_service.py
+++ b/python-service/app/services/chroma_service.py
@@ -81,9 +81,10 @@ class ChromaService:
             
             # Prepare data for ChromaDB
             ids = [f"{doc_id}::c{i}" for i in range(len(chunks))]
+            tags_str = ", ".join(request.tags)
             metadatas = [{
                 "title": request.title,
-                "tags": request.tags,
+                "tags": tags_str,
                 "created_at": datetime.now(timezone.utc).isoformat(),
                 "doc_id": doc_id,
                 "seq": i,


### PR DESCRIPTION
## Summary
- serialize tag lists into comma-separated strings before sending metadata to ChromaDB
- mock embedding setup and convert async tests to sync to avoid missing dependencies
- test upload ensures tags are stored as strings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/services/test_chroma_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68be9ae7ee2c8330843213d831063045