### PR TITLE
Load root env in Python service and test embedding provider

### DIFF
--- a/.env
+++ b/.env
@@ -32,6 +32,10 @@ OLLAMA_PORT=11434
 CHROMA_URL=chromadb
 CHROMA_PORT=8000
 
+# Embedding configuration
+EMBEDDING_PROVIDER=openai
+EMBEDDING_MODEL=text-embedding-3-small
+
 # Redis configuration
 REDIS_URL=redis://redis:6379/0
 REDIS_HOST=redis

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ OLLAMA_PORT=11434
 CHROMA_URL=chromadb
 CHROMA_PORT=8000
 
+# Embedding configuration
+EMBEDDING_PROVIDER=openai
+EMBEDDING_MODEL=text-embedding-3-small
+
 # Redis configuration
 REDIS_URL=redis://redis:6379/0
 REDIS_HOST=redis

--- a/python-service/app/core/config.py
+++ b/python-service/app/core/config.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, Union
 import os
+from pathlib import Path
 from urllib.parse import urlparse
 from loguru import logger
 from dotenv import load_dotenv
@@ -12,7 +13,7 @@ class Settings:
     """Application settings and configuration."""
 
     def __init__(self):
-        load_dotenv()
+        load_dotenv(Path(__file__).resolve().parents[3] / ".env")
         # API Configuration
         self.app_name: str = "Trainium Python AI Service"
         self.app_version: str = "1.0.0"

--- a/python-service/tests/services/test_embedding_factory.py
+++ b/python-service/tests/services/test_embedding_factory.py
@@ -2,7 +2,10 @@
 
 import pytest
 from unittest.mock import patch, MagicMock
+from pathlib import Path
+from dotenv import dotenv_values
 
+from app.core.config import settings
 from app.services.embeddings.factory import create_embedding_function, get_embedding_function
 
 
@@ -89,6 +92,12 @@ def test_get_embedding_function_openai():
         mock_create.return_value = mock_func
         
         result = get_embedding_function()
-        
+
         mock_create.assert_called_once_with("openai", "text-embedding-3-small")
         assert result == mock_func
+
+
+def test_settings_reads_embedding_provider_from_env():
+    """Settings should reflect EMBEDDING_PROVIDER from root .env."""
+    env = dotenv_values(Path(__file__).resolve().parents[3] / ".env")
+    assert settings.embedding_provider == env.get("EMBEDDING_PROVIDER")


### PR DESCRIPTION
## Summary
- ensure settings loads the project `.env` by resolving a fixed path
- document embedding provider defaults in `.env` files
- test that settings picks up `EMBEDDING_PROVIDER` from the root `.env`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/tests/services/test_embedding_factory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf3e23e5e0833087ca9dd4a02b54bb