### PR TITLE
Handle Chroma add errors and expose message

### DIFF
--- a/python-service/tests/services/test_chroma_service.py
+++ b/python-service/tests/services/test_chroma_service.py
@@ -98,7 +98,7 @@ class TestChromaService:
         
         # Verify failure response
         assert result.success is False
-        assert "ChromaDB connection failed" in result.message
+        assert result.message == "ChromaDB connection failed"
         assert result.chunks_created == 0
 
     @patch('app.services.chroma_service.get_chroma_client')
@@ -130,7 +130,7 @@ class TestChromaService:
         result = asyncio.run(chroma_service.upload_document(sample_request))
 
         assert result.success is False
-        assert "Dimension mismatch" in result.message
+        assert result.message == "Dimension mismatch: expected 1536, got 2"
     
     @patch('app.services.chroma_service.get_chroma_client')
     def test_list_collections(self, mock_get_client, chroma_service):


### PR DESCRIPTION
## Summary
- return ChromaDB error messages from collection.add failures
- surface raw exception text in ChromaUploadResponse
- adjust tests to expect exact error messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: expected call not found in create_llm_client)*
- `pytest python-service -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4554c4b88330ba0d15c64e3fdcd2