### PR TITLE
fix: render helper snapshot placeholders literally

### DIFF
--- a/python-service/app/services/crewai/job_posting_review/config/tasks.yaml
+++ b/python-service/app/services/crewai/job_posting_review/config/tasks.yaml
@@ -361,13 +361,13 @@ helper_snapshot:
     
     If {options.use_helpers} is true, run selected helper tasks and merge their JSON outputs into a single compact object (≤1.5 KB typical):
     {{
-      "data_analyst": {{tc_range, refs}},
-      "strategist": {{signals, refs}},
-      "stakeholder": {{partners, risks}},
-      "technical_leader": {{notes}},
-      "recruiter": {{keyword_gaps}},
-      "skeptic": {{redflags}},
-      "optimizer": {{top3}}
+      "data_analyst": {{{{tc_range, refs}}}},
+      "strategist": {{{{signals, refs}}}},
+      "stakeholder": {{{{partners, risks}}}},
+      "technical_leader": {{{{notes}}}},
+      "recruiter": {{{{keyword_gaps}}}},
+      "skeptic": {{{{redflags}}}},
+      "optimizer": {{{{top3}}}}
     }}
     
     Handle any helper task failures by using empty JSON for that helper key. Keep the merged object valid and compact.


### PR DESCRIPTION
## Summary
- escape helper snapshot placeholders with quadruple braces to render literally after formatting

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'python_service'; ModuleNotFoundError: No module named 'bleach')*
- `docker compose restart python-service` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c089d7605c8330bff01e50c25d9901