### PR TITLE
fix: escape helper snapshot template variables

### DIFF
--- a/python-service/app/services/crewai/job_posting_review/config/tasks.yaml
+++ b/python-service/app/services/crewai/job_posting_review/config/tasks.yaml
@@ -360,15 +360,17 @@ helper_snapshot:
     If {options.use_helpers} is false or missing, return empty JSON: {{}}
     
     If {options.use_helpers} is true, run selected helper tasks and merge their JSON outputs into a single compact object (≤1.5 KB typical):
-    {{
-      "data_analyst": {{{{tc_range, refs}}}},
-      "strategist": {{{{signals, refs}}}},
-      "stakeholder": {{{{partners, risks}}}},
-      "technical_leader": {{{{notes}}}},
-      "recruiter": {{{{keyword_gaps}}}},
-      "skeptic": {{{{redflags}}}},
-      "optimizer": {{{{top3}}}}
-    }}
+    {% raw %}
+    {
+      "data_analyst": {{"tc_range, refs"}},
+      "strategist": {{"signals, refs"}},
+      "stakeholder": {{"partners, risks"}},
+      "technical_leader": {{"notes"}},
+      "recruiter": {{"keyword_gaps"}},
+      "skeptic": {{"redflags"}},
+      "optimizer": {{"top3"}}
+    }
+    {% endraw %}
     
     Handle any helper task failures by using empty JSON for that helper key. Keep the merged object valid and compact.
   expected_output: "Compact merged JSON object from helper tasks (≤1.5 KB) or empty JSON if helpers disabled"


### PR DESCRIPTION
## Summary
- prevent helper snapshot template variables from being evaluated by wrapping the JSON mapping in `{% raw %}`/`{% endraw %}`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from unittest.mock import patch
from app.services.crewai.job_posting_review.crew import run_crew, LLMRouter
sample_job = {
    "title": "Senior Software Engineer",
    "company": "TechCorp",
    "location": "Remote",
    "description": "Develop and maintain systems"
}
with patch.object(LLMRouter, "generate", return_value="{}"):  # return empty JSON
    result = run_crew(job_posting_data=sample_job, options={"use_helpers": True}, correlation_id="test-log")
    print(result)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_68c0907fb60483308562bc659a85d078