### PR TITLE
Ensure error responses use string messages

### DIFF
--- a/python-service/app/schemas/responses.py
+++ b/python-service/app/schemas/responses.py
@@ -1,7 +1,6 @@
-"""
-Standard API response schemas and utilities.
-"""
-from typing import Any, Dict, Optional, Union
+"""Standard API response schemas and utilities."""
+from typing import Any, Dict, Optional
+import json
 from pydantic import BaseModel
 from enum import Enum
 
@@ -40,8 +39,18 @@ class ErrorDetail(BaseModel):
     details: Optional[Dict[str, Any]] = None
 
 
+def _stringify(value: Any) -> Optional[str]:
+    """Convert non-string values to JSON strings when possible."""
+    if value is None or isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value)
+    except TypeError:
+        return str(value)
+
+
 def create_success_response(
-    data: Any = None, 
+    data: Any = None,
     message: Optional[str] = None
 ) -> StandardResponse:
     """Create a standard success response."""
@@ -53,16 +62,16 @@ def create_success_response(
 
 
 def create_error_response(
-    error: str,
+    error: Any,
     data: Optional[Any] = None,
-    message: Optional[str] = None
+    message: Optional[Any] = None
 ) -> StandardResponse:
     """Create a standard error response."""
     return StandardResponse(
         status=ResponseStatus.ERROR,
-        error=error,
+        error=_stringify(error),
         data=data,
-        message=message
+        message=_stringify(message)
     )
 
 

--- a/python-service/main.py
+++ b/python-service/main.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 import traceback
+import json
 
 from app.core.config import configure_logging, get_settings
 from app.api.router import api_router
@@ -110,10 +111,16 @@ app.add_middleware(
 async def http_exception_handler(request: Request, exc: HTTPException):
     """Handle HTTP exceptions with structured error responses."""
     logger.error(f"HTTP exception: {exc.status_code} - {exc.detail}")
-    
+    message = exc.detail
+    if not isinstance(message, str):
+        try:
+            message = json.dumps(message)
+        except TypeError:
+            message = str(message)
+
     response = create_error_response(
         error=f"HTTP {exc.status_code}",
-        message=exc.detail
+        message=message
     )
     
     return JSONResponse(

--- a/python-service/tests/routes/test_jobs_fit_review.py
+++ b/python-service/tests/routes/test_jobs_fit_review.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+
+from main import app
+
+
+def test_fit_review_error_returns_string_message():
+    client = TestClient(app)
+    job_posting = {
+        "title": "Example",
+        "company": "ACME",
+        "location": "Remote",
+        "description": "Desc",
+        "url": "http://example.com",
+    }
+
+    with patch("app.routes.jobs_fit_review.run_crew", side_effect=Exception("boom")):
+        res = client.post(
+            "/jobs/posting/fit_review", json={"job_posting": job_posting}
+        )
+
+    assert res.status_code == 500
+    body = res.json()
+    assert body["status"] == "error"
+    assert isinstance(body["message"], str)
+    assert "fit_review_failed" in body["message"]
+


### PR DESCRIPTION
## Summary
- stringify non-string errors/messages in `create_error_response`
- serialize HTTPException details before creating error responses
- test that job fit review endpoint returns string message on 500s

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/routes/test_jobs_fit_review.py::test_fit_review_error_returns_string_message -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09353be108330ba50104c434eccee