### PR TITLE
feat: replace persona_id with id

### DIFF
--- a/python-service/tests/crewai/test_helpers_yaml.py
+++ b/python-service/tests/crewai/test_helpers_yaml.py
@@ -165,7 +165,7 @@ class TestHelpersYaml:
         assert prepared_inputs["options"].get("use_helpers") is False
         
         # Execute in mock mode
-        result = crew.process_verdicts({"mock_mode": True})
+        result = crew.process_verdicts({"mock_mode": True, "options": {"use_helpers": False}})
         
         # Verify helper_snapshot is empty or missing
         helper_snapshot = result.get("helper_snapshot", {})
@@ -178,7 +178,7 @@ class TestHelpersYaml:
         
         # Verify verdicts are well-formed
         for verdict in verdicts:
-            assert "persona_id" in verdict
+            assert "id" in verdict
             assert "recommend" in verdict
             assert "reason" in verdict
     
@@ -194,7 +194,7 @@ class TestHelpersYaml:
         assert prepared_inputs["options"].get("use_helpers") is True
         
         # Execute in mock mode
-        result = crew.process_verdicts({"mock_mode": True})
+        result = crew.process_verdicts({"mock_mode": True, "options": {"use_helpers": True}})
         
         # Verify helper_snapshot contains data
         assert "helper_snapshot" in result

--- a/python-service/tests/crewai/test_motivational_fanout_yaml.py
+++ b/python-service/tests/crewai/test_motivational_fanout_yaml.py
@@ -150,14 +150,14 @@ class TestMotivationalFanOutYaml:
         
         # Test each verdict structure
         expected_personas = ["builder", "maximizer", "harmonizer", "pathfinder", "adventurer"]
-        actual_personas = [v["persona_id"] for v in verdicts]
-        
+        actual_personas = [v["id"] for v in verdicts]
+
         for expected_persona in expected_personas:
             assert expected_persona in actual_personas, f"Missing persona {expected_persona}"
-        
+
         # Test verdict structure
         for verdict in verdicts:
-            assert "persona_id" in verdict, "Verdict missing persona_id"
+            assert "id" in verdict, "Verdict missing id"
             assert "recommend" in verdict, "Verdict missing recommend"
             assert "reason" in verdict, "Verdict missing reason"
             assert "notes" in verdict, "Verdict missing notes"
@@ -194,16 +194,16 @@ class TestMotivationalFanOutYaml:
             assert len(verdicts) == 5, "Should return verdicts for all 5 personas even with failures"
             
             # Check successful parsing
-            builder_verdict = next(v for v in verdicts if v["persona_id"] == "builder")
+            builder_verdict = next(v for v in verdicts if v["id"] == "builder")
             assert builder_verdict["recommend"] is True
             assert "Good tech stack" in builder_verdict["reason"]
             
             # Check failure handling
-            maximizer_verdict = next(v for v in verdicts if v["persona_id"] == "maximizer") 
+            maximizer_verdict = next(v for v in verdicts if v["id"] == "maximizer")
             assert maximizer_verdict["recommend"] is False
             assert "insufficient signal" in maximizer_verdict["reason"]
             
-            pathfinder_verdict = next(v for v in verdicts if v["persona_id"] == "pathfinder")
+            pathfinder_verdict = next(v for v in verdicts if v["id"] == "pathfinder")
             assert pathfinder_verdict["recommend"] is False
             assert "insufficient signal" in pathfinder_verdict["reason"]
     
@@ -233,7 +233,7 @@ class TestMotivationalFanOutYaml:
         assert len(personas) >= 5, "Should include all motivational evaluators"
         
         # Verify persona structure
-        persona_ids = [p.get("persona_id") for p in personas]
+        persona_ids = [p.get("id") for p in personas]
         expected_personas = ["builder", "maximizer", "harmonizer", "pathfinder", "adventurer"]
         for expected in expected_personas:
             assert expected in persona_ids, f"Missing {expected} in personas"

--- a/python-service/tests/crewai/test_motivational_with_helpers_yaml.py
+++ b/python-service/tests/crewai/test_motivational_with_helpers_yaml.py
@@ -114,8 +114,10 @@ class TestMotivationalWithHelpersYaml:
         
         verdicts = result["motivational_verdicts"]
         helper_snapshot = result["helper_snapshot"]
-        
+
         assert len(verdicts) == 5, "Should return 5 motivational verdicts"
+        for verdict in verdicts:
+            assert "id" in verdict
         assert len(helper_snapshot) > 0, "Should return non-empty helper snapshot"
         
         # Check that some motivational verdicts reference helper insights
@@ -150,7 +152,7 @@ class TestMotivationalWithHelpersYaml:
         parsed_verdict = crew._parse_verdict(mock_verdict_with_helpers, "maximizer")
         
         # Verify structure is maintained
-        required_fields = ["persona_id", "recommend", "reason", "notes", "sources"]
+        required_fields = ["id", "recommend", "reason", "notes", "sources"]
         for field in required_fields:
             assert field in parsed_verdict, f"Verdict should contain {field}"
         
@@ -185,7 +187,7 @@ class TestMotivationalWithHelpersYaml:
         parsed_verdict = crew._parse_verdict(mock_verdict_no_helpers, "builder")
         
         # Verify it works without helper references
-        assert parsed_verdict["persona_id"] == "builder"
+        assert parsed_verdict["id"] == "builder"
         assert parsed_verdict["recommend"] is True
         assert len(parsed_verdict["reason"]) > 0
         assert len(parsed_verdict["notes"]) > 0
@@ -289,7 +291,7 @@ class TestMotivationalWithHelpersYaml:
         mock_result = {
             "motivational_verdicts": [
                 {
-                    "persona_id": f"persona_{i}",
+                    "id": f"persona_{i}",
                     "recommend": True,
                     "reason": f"Test reason {i} with helper insights from market data",
                     "notes": [f"note {i}a", f"note {i}b"],
@@ -356,21 +358,21 @@ class TestMotivationalWithHelpersYaml:
         # Verify each persona maintains quality standards
         for persona in personas:
             # Required fields
-            assert "persona_id" in persona
+            assert "id" in persona
             assert "recommend" in persona
             assert "reason" in persona
             assert "notes" in persona
             assert "sources" in persona
-            
+
             # Quality checks
-            assert len(persona["reason"]) > 10, f"Reason for {persona['persona_id']} should be meaningful"
-            assert len(persona["reason"]) <= 300, f"Reason for {persona['persona_id']} should be concise"
-            assert len(persona["notes"]) > 0, f"Notes for {persona['persona_id']} should not be empty"
-            assert len(persona["sources"]) > 0, f"Sources for {persona['persona_id']} should not be empty"
-            
+            assert len(persona["reason"]) > 10, f"Reason for {persona['id']} should be meaningful"
+            assert len(persona["reason"]) <= 300, f"Reason for {persona['id']} should be concise"
+            assert len(persona["notes"]) > 0, f"Notes for {persona['id']} should not be empty"
+            assert len(persona["sources"]) > 0, f"Sources for {persona['id']} should not be empty"
+
             # Persona ID should be valid
             valid_personas = ["builder", "maximizer", "harmonizer", "pathfinder", "adventurer"]
-            assert persona["persona_id"] in valid_personas, f"Invalid persona_id: {persona['persona_id']}"
+            assert persona["id"] in valid_personas, f"Invalid persona id: {persona['id']}"
         
         # Check for appropriate helper integration
         final_rationale = result["final"]["rationale"]


### PR DESCRIPTION
## Summary
- ensure crew and mock verdicts use `id` instead of `persona_id`
- update motivational crew tests to expect `id` in persona verdicts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `DATABASE_URL=sqlite:// pytest python-service/tests/crewai -q`
- `PYTHONPATH=python-service python - <<'PY'
from app.models.fit_review import FitReviewResult
FitReviewResult.model_validate({
 "job_id":"1",
 "final":{"recommend":True,"rationale":"ok","confidence":"high"},
 "personas":[{"id":"builder","recommend":True,"reason":"","notes":[],"sources":[]}],
 "tradeoffs":[],"actions":[],"sources":[]
})
print('validated')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c097f74ac08330a71347a3943141a6