### PR TITLE
feat: support metadata for Chroma uploads

### DIFF
--- a/components/ChromaUploadView.tsx
+++ b/components/ChromaUploadView.tsx
@@ -29,8 +29,35 @@ export const ChromaUploadView: React.FC<ChromaUploadProps> = ({ onBack }) => {
     const [collections, setCollections] = useState<CollectionInfo[]>([]);
     const [isLoadingCollections, setIsLoadingCollections] = useState(false);
     const [showCollections, setShowCollections] = useState(false);
-    
+    const [metadata, setMetadata] = useState<Record<string, string>>({});
+
     const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const addMetadataField = () => {
+        setMetadata(prev => ({ ...prev, [`__key${Object.keys(prev).length}`]: '' }));
+    };
+
+    const updateMetadataKey = (oldKey: string, newKey: string) => {
+        setMetadata(prev => {
+            const updated = { ...prev } as Record<string, string>;
+            const value = updated[oldKey];
+            delete updated[oldKey];
+            updated[newKey] = value;
+            return updated;
+        });
+    };
+
+    const updateMetadataValue = (key: string, value: string) => {
+        setMetadata(prev => ({ ...prev, [key]: value }));
+    };
+
+    const removeMetadataField = (key: string) => {
+        setMetadata(prev => {
+            const updated = { ...prev } as Record<string, string>;
+            delete updated[key];
+            return updated;
+        });
+    };
 
     const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
@@ -68,6 +95,13 @@ export const ChromaUploadView: React.FC<ChromaUploadProps> = ({ onBack }) => {
             formData.append('collection_name', collectionName.trim());
             formData.append('title', title.trim());
             formData.append('tags', tags.trim());
+            const filteredMetadata = Object.entries(metadata).reduce((acc, [k, v]) => {
+                if (k && !k.startsWith('__key') && v) {
+                    acc[k] = v;
+                }
+                return acc;
+            }, {} as Record<string, string>);
+            formData.append('metadata', JSON.stringify(filteredMetadata));
             formData.append('file', selectedFile);
 
             const response = await fetch('http://localhost:8000/chroma/upload', {
@@ -84,6 +118,7 @@ export const ChromaUploadView: React.FC<ChromaUploadProps> = ({ onBack }) => {
                 setTitle('');
                 setTags('');
                 setSelectedFile(null);
+                setMetadata({});
                 if (fileInputRef.current) {
                     fileInputRef.current.value = '';
                 }
@@ -238,6 +273,45 @@ export const ChromaUploadView: React.FC<ChromaUploadProps> = ({ onBack }) => {
                         <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
                             Separate multiple tags with commas
                         </p>
+                    </div>
+
+                    {/* Metadata */}
+                    <div className="space-y-2">
+                        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+                            Metadata (Optional)
+                        </label>
+                        {Object.entries(metadata).map(([key, value], idx) => (
+                            <div key={idx} className="flex items-center space-x-2">
+                                <input
+                                    type="text"
+                                    placeholder="Key"
+                                    value={key.startsWith('__key') ? '' : key}
+                                    onChange={(e) => updateMetadataKey(key, e.target.value)}
+                                    className="flex-1 p-2 border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                />
+                                <input
+                                    type="text"
+                                    placeholder="Value"
+                                    value={value}
+                                    onChange={(e) => updateMetadataValue(key, e.target.value)}
+                                    className="flex-1 p-2 border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => removeMetadataField(key)}
+                                    className="px-2 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                                >
+                                    Remove
+                                </button>
+                            </div>
+                        ))}
+                        <button
+                            type="button"
+                            onClick={addMetadataField}
+                            className="text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200"
+                        >
+                            Add Metadata
+                        </button>
                     </div>
 
                     {/* File Upload */}

--- a/python-service/app/schemas/chroma.py
+++ b/python-service/app/schemas/chroma.py
@@ -1,16 +1,20 @@
 """Schemas for ChromaDB operations."""
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
 
 
 class ChromaUploadRequest(BaseModel):
     """Request schema for uploading data to ChromaDB."""
-    
+
     collection_name: str = Field(..., description="Name of the ChromaDB collection")
     title: str = Field(..., description="Title for the document")
     tags: List[str] = Field(default_factory=list, description="Tags for the document")
     document_text: str = Field(..., description="The text content to upload")
+    metadata: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Additional metadata to include with each chunk",
+    )
 
 
 class ChromaUploadResponse(BaseModel):

--- a/python-service/app/services/chroma_service.py
+++ b/python-service/app/services/chroma_service.py
@@ -155,15 +155,19 @@ class ChromaService:
             # Prepare data for ChromaDB
             ids = [f"{doc_id}::c{i}" for i in range(len(chunks))]
             tags_str = ", ".join(request.tags)
-            metadatas = [{
-                "title": request.title,
-                "tags": tags_str,
-                "created_at": datetime.now(timezone.utc).isoformat(),
-                "doc_id": doc_id,
-                "seq": i,
-                "content_hash": self._sha1_hash(chunks[i]),
-                "type": "user_document"
-            } for i in range(len(chunks))]
+            created_at = datetime.now(timezone.utc).isoformat()
+            metadatas = []
+            for i, chunk in enumerate(chunks):
+                base_metadata = {
+                    "title": request.title,
+                    "tags": tags_str,
+                    "created_at": created_at,
+                    "doc_id": doc_id,
+                    "seq": i,
+                    "content_hash": self._sha1_hash(chunk),
+                    "type": "user_document",
+                }
+                metadatas.append({**base_metadata, **request.metadata})
             
             # Add to collection with explicit error handling
             try:

--- a/python-service/tests/services/test_chroma_service.py
+++ b/python-service/tests/services/test_chroma_service.py
@@ -29,7 +29,8 @@ class TestChromaService:
             collection_name="test_collection",
             title="Test Document",
             tags=["test", "sample"],
-            document_text="This is a test document with some content for testing purposes."
+            document_text="This is a test document with some content for testing purposes.",
+            metadata={"source": "unit-test"}
         )
     
     def test_chunk_text_basic(self, chroma_service):
@@ -86,6 +87,7 @@ class TestChromaService:
         metadatas = kwargs["metadatas"]
         assert all(isinstance(md["tags"], str) for md in metadatas)
         assert metadatas[0]["tags"] == "test, sample"
+        assert metadatas[0]["source"] == "unit-test"
     
     @patch('app.services.chroma_service.get_chroma_client')
     def test_upload_document_failure(self, mock_get_client, chroma_service, sample_request):


### PR DESCRIPTION
## Summary
- allow custom metadata in `ChromaUploadRequest`
- accept metadata JSON in upload endpoint and merge into chunk metadata
- add frontend controls to send metadata with uploads

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/services/test_chroma_service.py::TestChromaService::test_upload_document_success -q`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c0f5564070833093e27e905dd01afa