### PR TITLE
feat(jobspy): add endpoint to list supported job sites

### DIFF
--- a/python-service/app/api/v1/endpoints/jobspy.py
+++ b/python-service/app/api/v1/endpoints/jobspy.py
@@ -11,7 +11,7 @@ from ....schemas.responses import (
     create_success_response,
     create_error_response,
 )
-from ....schemas.jobspy import JobSearchRequest
+from ....schemas.jobspy import JobSearchRequest, JobSite
 from ....dependencies import (
     get_jobspy_service,
     get_queue_service,
@@ -235,6 +235,22 @@ async def get_scrape_status(
     except Exception as e:
         logger.error(f"Error getting scrape status for {run_id}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Failed to get scrape status: {str(e)}")
+
+
+@router.get("/sites/names", response_model=StandardResponse)
+async def list_supported_sites() -> StandardResponse:
+    """List supported job sites based on the JobSite enum."""
+    try:
+        sites = [site.value for site in JobSite]
+        return create_success_response(
+            data={"sites": sites},
+            message="Supported job sites retrieved successfully",
+        )
+    except Exception as e:
+        logger.error(f"Error listing supported sites: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to list supported sites: {str(e)}"
+        )
 
 
 @router.get("/sites", response_model=StandardResponse)

--- a/python-service/docs/JOBSPY_INTEGRATION.md
+++ b/python-service/docs/JOBSPY_INTEGRATION.md
@@ -29,6 +29,9 @@ Scrape jobs from a specified job board.
 ### GET `/jobs/sites`
 Get information about supported job sites.
 
+### GET `/jobs/sites/names`
+List the identifiers of supported job sites.
+
 ### GET `/jobs/health`
 Check JobSpy service health status.
 

--- a/python-service/integration_test.py
+++ b/python-service/integration_test.py
@@ -96,7 +96,14 @@ async def test_api_endpoints():
     scheduler_routes = [route.path for route in scheduler_router.routes]
     
     # Validate jobspy endpoints
-    expected_jobspy_routes = ['/scrape', '/scrape/{run_id}', '/sites', '/health', '/queue/status']
+    expected_jobspy_routes = [
+        '/scrape',
+        '/scrape/{run_id}',
+        '/sites',
+        '/sites/names',
+        '/health',
+        '/queue/status'
+    ]
     for expected_route in expected_jobspy_routes:
         assert any(expected_route in route for route in jobspy_routes), f"Missing route: {expected_route}"
     


### PR DESCRIPTION
## Summary
- add `/jobs/sites/names` endpoint that returns supported job site identifiers
- document new endpoint and update integration tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python python-service/integration_test.py` *(fails: DATABASE_URL is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bde2798883309e18e0a71836bcca