### PR TITLE
feat(jobspy): add endpoint to list supported job sites

### DIFF
--- a/python-service/app/api/v1/endpoints/jobspy.py
+++ b/python-service/app/api/v1/endpoints/jobspy.py
@@ -11,7 +11,7 @@ from ....schemas.responses import (
     create_success_response,
     create_error_response,
 )
-from ....schemas.jobspy import JobSearchRequest
+from ....schemas.jobspy import JobSearchRequest, JobSite
 from ....dependencies import (
     get_jobspy_service,
     get_queue_service,
@@ -235,6 +235,22 @@ async def get_scrape_status(
     except Exception as e:
         logger.error(f"Error getting scrape status for {run_id}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Failed to get scrape status: {str(e)}")
+
+
+@router.get("/sites/names", response_model=StandardResponse)
+async def list_supported_sites() -> StandardResponse:
+    """List supported job sites based on the JobSite enum."""
+    try:
+        sites = [site.value for site in JobSite]
+        return create_success_response(
+            data={"sites": sites},
+            message="Supported job sites retrieved successfully",
+        )
+    except Exception as e:
+        logger.error(f"Error listing supported sites: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to list supported sites: {str(e)}"
+        )
 
 
 @router.get("/sites", response_model=StandardResponse)

--- a/python-service/app/services/jobspy/ingestion.py
+++ b/python-service/app/services/jobspy/ingestion.py
@@ -172,7 +172,7 @@ class JobSpyIngestionService:
                         if request.easy_apply is not None:
                             kwargs["easy_apply"] = request.easy_apply
                             kwargs.pop("hours_old", None)
-                    elif site == "zip_recruiter":
+                    elif site == "ziprecruiter":
                         # no special params beyond the general ones; note hours_old rounds to next day upstream
                         pass
 
@@ -246,7 +246,10 @@ class JobSpyIngestionService:
                     "supports_remote": True,
                     "supports_salary_filter": True,
                     "requires": ["country_indeed"],
-                    "limits": ["only one of: hours_old OR (job_type/is_remote) OR easy_apply"],
+                    "conflicts": [
+                        "hours_old conflicts with job_type/is_remote/easy_apply",
+                        "easy_apply conflicts with job_type/is_remote"
+                    ],
                     "notes": ["Best scraper; low rate limiting"]
                 },
                 "glassdoor": {
@@ -254,19 +257,23 @@ class JobSpyIngestionService:
                     "supports_remote": True,
                     "supports_salary_filter": True,
                     "requires": ["country_indeed"],
+                    "conflicts": [],
                     "notes": ["hours_old rounds to next day"]
                 },
                 "linkedin": {
                     "name": "LinkedIn",
                     "supports_remote": True,
                     "supports_salary_filter": False,
+                    "requires": [],
                     "optional": ["linkedin_fetch_description", "linkedin_company_ids"],
-                    "limits": ["only one of: hours_old OR easy_apply"]
+                    "conflicts": ["only one of: hours_old or easy_apply"],
                 },
-                "zip_recruiter": {
+                "ziprecruiter": {
                     "name": "ZipRecruiter",
                     "supports_remote": True,
                     "supports_salary_filter": True,
+                    "requires": [],
+                    "conflicts": [],
                     "notes": ["hours_old rounds to next day"]
                 },
                 "google": {
@@ -274,6 +281,7 @@ class JobSpyIngestionService:
                     "supports_remote": True,
                     "supports_salary_filter": False,
                     "requires": ["google_search_term"],
+                    "conflicts": [],
                     "notes": ["structured filters are ignored; use full-text query"]
                 }
             }

--- a/python-service/docs/JOBSPY_INTEGRATION.md
+++ b/python-service/docs/JOBSPY_INTEGRATION.md
@@ -27,7 +27,10 @@ Scrape jobs from a specified job board.
 ```
 
 ### GET `/jobs/sites`
-Get information about supported job sites.
+Get information about supported job sites, including required filters and any conflicting criteria.
+
+### GET `/jobs/sites/names`
+List the identifiers of supported job sites.
 
 ### GET `/jobs/health`
 Check JobSpy service health status.

--- a/python-service/integration_test.py
+++ b/python-service/integration_test.py
@@ -5,11 +5,15 @@ Tests the basic functionality without requiring live database or Redis.
 """
 import sys
 import asyncio
+import os
 from pathlib import Path
 from unittest.mock import Mock, AsyncMock, patch
 
 # Add the project root to Python path
 sys.path.insert(0, Path(__file__).resolve().parent.as_posix())
+
+# Provide default configuration values required by settings
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost:5432/db")
 
 from loguru import logger
 
@@ -90,13 +94,21 @@ async def test_api_endpoints():
     from app.api.v1.endpoints.jobspy import router as jobspy_router
     from app.api.v1.endpoints.scheduler import router as scheduler_router
     from app.api.router import api_router
+    from app.services.jobspy.ingestion import JobSpyIngestionService
     
     # Check that routers have the expected endpoints
     jobspy_routes = [route.path for route in jobspy_router.routes]
     scheduler_routes = [route.path for route in scheduler_router.routes]
     
     # Validate jobspy endpoints
-    expected_jobspy_routes = ['/scrape', '/scrape/{run_id}', '/sites', '/health', '/queue/status']
+    expected_jobspy_routes = [
+        '/scrape',
+        '/scrape/{run_id}',
+        '/sites',
+        '/sites/names',
+        '/health',
+        '/queue/status'
+    ]
     for expected_route in expected_jobspy_routes:
         assert any(expected_route in route for route in jobspy_routes), f"Missing route: {expected_route}"
     
@@ -106,6 +118,16 @@ async def test_api_endpoints():
         assert any(expected_route in route for route in scheduler_routes), f"Missing route: {expected_route}"
     
     print("✅ All expected API endpoints are registered!")
+
+    # Validate supported sites include requirement and conflict info
+    service = JobSpyIngestionService()
+    supported = await service.get_supported_sites()
+    assert supported.data, "Supported sites data missing"
+    for site in JobSite:
+        info = supported.data.get(site.value)
+        assert info is not None, f"Missing site info for {site.value}"
+        assert "requires" in info, f"Missing 'requires' for {site.value}"
+        assert "conflicts" in info, f"Missing 'conflicts' for {site.value}"
 
 
 def test_service_initialization():


### PR DESCRIPTION
## Summary
- expand `/jobs/sites` to report required filters and conflicting criteria for each supported job board
- fix ZipRecruiter identifier so filter logic works consistently
- document new fields and validate them in integration tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python python-service/integration_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1bde2798883309e18e0a71836bcca