### PR TITLE
feat: wrap MCP tools as LangChain BaseTool

### DIFF
--- a/python-service/app/services/crewai/job_review/crew.py
+++ b/python-service/app/services/crewai/job_review/crew.py
@@ -12,6 +12,7 @@ from loguru import logger
 from crewai import Agent, Crew, Task, Process
 from crewai.project import CrewBase, agent, task, crew, before_kickoff, after_kickoff
 from crewai.llm import BaseLLM
+from langchain.tools import BaseTool
 
 from .. import base
 from ...ai.llm_clients import LLMRouter
@@ -39,7 +40,7 @@ class JobReviewCrew:
         self._agent_llms: Dict[str, BaseLLM] = {}
         self.tasks_config = base.load_tasks_config(self.base_dir, "job_review/config")
 
-    def _load_tools(self, tool_names: List[str]) -> List[Any]:
+    def _load_tools(self, tool_names: List[str]) -> List[BaseTool]:
         """Resolve tool names to actual implementations using MCP Gateway.
 
         Loads tools from MCP servers through the Docker MCP Gateway.
@@ -52,7 +53,7 @@ class JobReviewCrew:
             # Load tools from MCP Gateway
             mcp_tools = base.load_mcp_tools_sync(tool_names)
             if mcp_tools:
-                logger.info(f"Loaded {len(mcp_tools)} MCP tools: {[t.get('name', 'unknown') for t in mcp_tools]}")
+                logger.info(f"Loaded {len(mcp_tools)} MCP tools: {[t.name for t in mcp_tools]}")
                 return mcp_tools
             else:
                 logger.warning(f"No MCP tools loaded for: {tool_names}")

--- a/python-service/test_mcp_integration.py
+++ b/python-service/test_mcp_integration.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).parent / "app"))
 
 from app.services.mcp_adapter import MCPServerAdapter, get_mcp_adapter
 from app.services.crewai import base
+from langchain.tools import BaseTool
 from app.core.config import get_settings
 from loguru import logger
 
@@ -65,9 +66,10 @@ def test_crewai_tool_loading():
         # Test sync tool loading
         tools = base.load_mcp_tools_sync(["web_search"])
         logger.info(f"Loaded {len(tools)} tools through sync loader")
-        
+
         for tool in tools:
-            logger.info(f"  - {tool.get('name')}: {tool.get('description')}")
+            assert isinstance(tool, BaseTool)
+            logger.info(f"  - {tool.name}: {tool.description}")
             
         # Test DuckDuckGo specific loading
         duckduckgo_tools = base.get_duckduckgo_tools()
@@ -104,9 +106,9 @@ async def test_job_review_crew_integration():
         
         mcp_tools = prepared_inputs.get("mcp_tools", [])
         logger.info(f"JobReviewCrew loaded {len(mcp_tools)} MCP tools")
-        
+
         for tool in mcp_tools:
-            logger.info(f"  - {tool.get('name')}: {tool.get('description', 'No description')}")
+            logger.info(f"  - {tool.name}: {getattr(tool, 'description', 'No description')}")
             
         return len(mcp_tools) > 0
         


### PR DESCRIPTION
## Summary
- wrap MCP tools in `MCPDynamicTool` subclass of `BaseTool`
- load MCP tools as `MCPDynamicTool` instances and adjust JobReview crew to consume them
- update integration tests to expect `BaseTool` objects

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/test_mcp_integration.py -q` *(fails: ModuleNotFoundError: No module named 'mcp')*
- `pytest python-service/tests -q` *(fails: ModuleNotFoundError: No module named 'mcp')*


------
https://chatgpt.com/codex/tasks/task_e_68c2013f820483308ef37ab88f638936