### PR TITLE
refactor: use CrewAI BaseTool for MCP tools

### DIFF
--- a/python-service/app/services/crewai/base.py
+++ b/python-service/app/services/crewai/base.py
@@ -13,11 +13,11 @@ import asyncio
 
 from ..mcp_adapter import get_mcp_adapter, create_sync_tool_wrapper
 from ...core.config import get_settings
-from langchain.tools import BaseTool
+from crewai.tools import BaseTool
 
 
 class MCPDynamicTool(BaseTool):
-    """Lightweight wrapper around MCP tools for LangChain compatibility."""
+    """Lightweight wrapper around MCP tools for CrewAI compatibility."""
 
     name: str
     description: str = ""

--- a/python-service/app/services/crewai/job_review/crew.py
+++ b/python-service/app/services/crewai/job_review/crew.py
@@ -12,7 +12,7 @@ from loguru import logger
 from crewai import Agent, Crew, Task, Process
 from crewai.project import CrewBase, agent, task, crew, before_kickoff, after_kickoff
 from crewai.llm import BaseLLM
-from langchain.tools import BaseTool
+from crewai.tools import BaseTool
 
 from .. import base
 from ...ai.llm_clients import LLMRouter

--- a/python-service/app/services/crewai/tools/chroma_search.py
+++ b/python-service/app/services/crewai/tools/chroma_search.py
@@ -1,4 +1,4 @@
-from langchain.tools import BaseTool
+from crewai.tools import BaseTool
 from typing import Optional
 import os
 

--- a/python-service/app/services/crewai/tools/custom_pg.py
+++ b/python-service/app/services/crewai/tools/custom_pg.py
@@ -1,4 +1,4 @@
-from langchain.tools import BaseTool
+from crewai.tools import BaseTool
 import psycopg, os
 from typing import Optional
 

--- a/python-service/test_mcp_integration.py
+++ b/python-service/test_mcp_integration.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parent / "app"))
 
 from app.services.mcp_adapter import MCPServerAdapter, get_mcp_adapter
 from app.services.crewai import base
-from langchain.tools import BaseTool
+from crewai.tools import BaseTool
 from app.core.config import get_settings
 from loguru import logger
 


### PR DESCRIPTION
## Summary
- switch MCP tooling from LangChain's BaseTool to CrewAI's BaseTool
- update MCPDynamicTool and consumer modules to reference CrewAI BaseTool
- adjust integration tests to validate CrewAI BaseTool types

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c2034cd2c48330b2de80d6c74fb7a5