### PR TITLE
feat: integrate DuckDuckGo MCP server

### DIFF
--- a/python-service/Dockerfile.mcp-gateway
+++ b/python-service/Dockerfile.mcp-gateway
@@ -8,12 +8,14 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install basic packages without MCP (for development/demo)
+# Install FastAPI and MCP dependencies including DuckDuckGo server
 RUN pip install --no-cache-dir \
     fastapi==0.116.1 \
     uvicorn[standard]==0.35.0 \
     httpx==0.28.1 \
-    loguru==0.7.3
+    loguru==0.7.3 \
+    mcp==1.13.1 \
+    mcp-server-duckduckgo
 
 # Copy MCP Gateway implementation
 COPY mcp_gateway.py /app/

--- a/python-service/mcp-config/servers.json
+++ b/python-service/mcp-config/servers.json
@@ -4,25 +4,7 @@
       "command": "python",
       "args": ["-m", "mcp_server_duckduckgo"],
       "env": {},
-      "description": "DuckDuckGo search server for web searches",
-      "capabilities": {
-        "tools": {
-          "web_search": {
-            "description": "Search the web using DuckDuckGo",
-            "parameters": {
-              "query": {
-                "type": "string", 
-                "description": "Search query"
-              },
-              "max_results": {
-                "type": "integer",
-                "description": "Maximum number of results to return",
-                "default": 5
-              }
-            }
-          }
-        }
-      }
+      "description": "DuckDuckGo search server for web searches"
     }
   },
   "gateway": {

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -46,5 +46,6 @@ torch==2.2.0
 
 # MCP (Model Context Protocol) support
 mcp==1.13.1
+mcp-server-duckduckgo
 
 


### PR DESCRIPTION
## Summary
- install mcp-server-duckduckgo and toolkit in the MCP gateway
- replace mock MCP gateway with real subprocess-based implementation
- point MCP config to the DuckDuckGo server

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python validate_mcp_integration.py` *(fails: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_68c2074c9b088330acfb3e409ac59d47