### PR TITLE
Add job posting fit review endpoint

### DIFF
--- a/python-service/app/api/router.py
+++ b/python-service/app/api/router.py
@@ -6,6 +6,7 @@ from app.api.v1.endpoints.jobspy import router as jobspy_router
 from app.api.v1.endpoints.scheduler import router as scheduler_router
 from app.api.v1.endpoints.crewai_personal_brand import router as crewai_personal_brand_router
 from app.api.v1.endpoints.chroma import router as chroma_router
+from app.api.v1.endpoints.job_posting_review import router as job_posting_review_router
 
 api_router = APIRouter()
 
@@ -14,5 +15,6 @@ api_router.include_router(jobspy_router, prefix="/jobs", tags=["jobs", "scraping
 api_router.include_router(scheduler_router, prefix="/scheduler", tags=["scheduler"])
 api_router.include_router(crewai_personal_brand_router, tags=["job-review", "crewai"])
 api_router.include_router(chroma_router, tags=["chroma", "vector-database"])
+api_router.include_router(job_posting_review_router, tags=["job-review", "crewai"])
 
 __all__ = ["api_router"]

--- a/python-service/app/api/v1/endpoints/job_posting_review.py
+++ b/python-service/app/api/v1/endpoints/job_posting_review.py
@@ -1,0 +1,17 @@
+"""Endpoints for analyzing job posting fit using CrewAI."""
+
+from typing import Any, Dict
+
+from fastapi import APIRouter
+
+from ....schemas.responses import StandardResponse, create_success_response
+from ....services.crewai import get_job_review_crew
+
+router = APIRouter()
+
+
+@router.post("/jobs/posting/fit_review", response_model=StandardResponse)
+async def job_posting_fit_review(job_data: Dict[str, Any]) -> StandardResponse:
+    """Review a job posting and return fit analysis."""
+    result = get_job_review_crew().job_review().kickoff(inputs={"job": job_data})
+    return create_success_response(data=result.raw)


### PR DESCRIPTION
## Summary
- add CrewAI-based job posting fit review endpoint returning `StandardResponse`
- register new job review router with the main API router

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c217a3ca0c83308ce37d907026032f