### PR TITLE
chore: remove duckduckgo mcp server

### DIFF
--- a/python-service/Dockerfile.mcp-gateway
+++ b/python-service/Dockerfile.mcp-gateway
@@ -8,14 +8,13 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install FastAPI and MCP dependencies including DuckDuckGo server
+# Install FastAPI and MCP dependencies
 RUN pip install --no-cache-dir \
     fastapi==0.116.1 \
     uvicorn[standard]==0.35.0 \
     httpx==0.28.1 \
     loguru==0.7.3 \
-    mcp==1.13.1 \
-    mcp-server-duckduckgo
+    mcp==1.13.1
 
 # Copy MCP Gateway implementation
 COPY mcp_gateway.py /app/

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -46,6 +46,5 @@ torch==2.2.0
 
 # MCP (Model Context Protocol) support
 mcp==1.13.1
-mcp-server-duckduckgo
 
 


### PR DESCRIPTION
## Summary
- drop mcp-server-duckduckgo from python service requirements and Dockerfile
- keep core mcp toolkit for gateway server management

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c2561ffb488330b35659f3fe040771