### PR TITLE
Expose Docker socket to MCP gateway and install Docker CLI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,6 +221,7 @@ services:
       - MCP_SERVERS_CONFIG=/config/servers.json
     volumes:
       - ./python-service/mcp-config:/config:ro
+      - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s

--- a/python-service/Dockerfile.mcp-gateway
+++ b/python-service/Dockerfile.mcp-gateway
@@ -6,6 +6,7 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     curl \
+    docker-cli \
     && rm -rf /var/lib/apt/lists/*
 
 # Install FastAPI and MCP dependencies


### PR DESCRIPTION
## Summary
- install Docker CLI in MCP Gateway image
- mount host docker socket into mcp-gateway service

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c256e33c1883309b1dc5eb2bc2508e