### PR TITLE
Use Docker for DuckDuckGo MCP server

### DIFF
--- a/python-service/mcp-config/servers.json
+++ b/python-service/mcp-config/servers.json
@@ -1,8 +1,8 @@
 {
   "servers": {
     "duckduckgo": {
-      "command": "python",
-      "args": ["-m", "mcp_server_duckduckgo"],
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "mcp/duckduckgo"],
       "env": {},
       "description": "DuckDuckGo search server for web searches"
     }


### PR DESCRIPTION
## Summary
- configure DuckDuckGo MCP server to launch via Docker container

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker compose build mcp-gateway` *(fails: command not found: docker)*
- `curl -v http://localhost:8080/servers` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c257a3b1e48330b4d6b45206469fe0