### PR TITLE
Use official MCP package for MCP gateway

### DIFF
--- a/python-service/Dockerfile.mcp-gateway
+++ b/python-service/Dockerfile.mcp-gateway
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir \
     uvicorn[standard]==0.35.0 \
     httpx==0.28.1 \
     loguru==0.7.3 \
-    mcp==1.13.1
+    model-context-protocol
 
 # Copy MCP Gateway implementation
 COPY mcp_gateway.py /app/

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -45,6 +45,6 @@ sentence-transformers==4.1.0
 torch==2.2.0
 
 # MCP (Model Context Protocol) support
-mcp==1.13.1
+model-context-protocol
 
 


### PR DESCRIPTION
## Summary
- Replace deprecated `mcp` package with official `model-context-protocol` in MCP gateway Dockerfile
- Update Python service requirements to use `model-context-protocol`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `apt-get install -y docker.io` *(fails: Unable to locate package docker.io)*
- `docker build -t mcp-gateway-test -f python-service/Dockerfile.mcp-gateway python-service` *(fails: command not found)*
- `docker run --rm mcp-gateway-test python -c "from mcp.transport import SubprocessTransport"` *(fails: command not found)*
- `docker compose up -d mcp-gateway` *(fails: command not found)*
- `curl -sS http://localhost:8080/servers` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c259874d548330832caa978f2737af