### PR TITLE
chore: use published MCP package

### DIFF
--- a/python-service/Dockerfile.mcp-gateway
+++ b/python-service/Dockerfile.mcp-gateway
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir \
     uvicorn[standard]==0.35.0 \
     httpx==0.28.1 \
     loguru==0.7.3 \
-    model-context-protocol
+    mcp
 
 # Copy MCP Gateway implementation
 COPY mcp_gateway.py /app/

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -45,6 +45,6 @@ sentence-transformers==4.1.0
 torch==2.2.0
 
 # MCP (Model Context Protocol) support
-model-context-protocol
+mcp
 
 


### PR DESCRIPTION
## Summary
- replace `model-context-protocol` dependency with `mcp`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker build -f python-service/Dockerfile.mcp-gateway -t mcp-gateway python-service` *(fails: command not found: docker)*
- `pip install mcp` *(fails: Could not find a version that satisfies the requirement mcp: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c25b0caad48330bad96c5d85b276e1