### PR TITLE
Handle invalid JSON in company report service

### DIFF
--- a/python-service/app/services/company_service.py
+++ b/python-service/app/services/company_service.py
@@ -1,8 +1,13 @@
 import json
 from app.services.crewai.research_company.crew import get_research_company_crew
 
+
 def generate_company_report(company_name: str) -> dict:
     """Run CrewAI and return parsed JSON report."""
     crew = get_research_company_crew()
     result = crew.kickoff(inputs={"company_name": company_name})
-    return json.loads(result)
+    raw_output = getattr(result, "raw", str(result))
+    try:
+        return json.loads(raw_output)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid JSON output from CrewAI") from exc

--- a/tests/test_company_report_invalid_json.py
+++ b/tests/test_company_report_invalid_json.py
@@ -1,0 +1,19 @@
+def test_generate_company_report_invalid_json(monkeypatch):
+    class MockCrew:
+        def kickoff(self, inputs):
+            return "not json"
+
+    monkeypatch.setattr(
+        "app.services.company_service.get_research_company_crew",
+        lambda: MockCrew(),
+    )
+
+    from app.services.company_service import generate_company_report
+
+    try:
+        generate_company_report("SampleCo")
+    except ValueError as e:
+        assert "Invalid JSON" in str(e)
+    else:
+        assert False, "ValueError was not raised for invalid JSON"
+


### PR DESCRIPTION
## Summary
- parse CrewAI responses using `result.raw` and add error handling for invalid JSON in company report service
- test invalid JSON scenario in company report service

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'python_service'; ModuleNotFoundError: No module named 'mcp'; ModuleNotFoundError: No module named 'bleach')*
- `pip install mcp bleach` *(fails: Could not find a version that satisfies the requirement mcp; Could not find a version that satisfies the requirement bleach)*
- `pytest tests/test_company_news.py tests/test_company_report_invalid_json.py`

------
https://chatgpt.com/codex/tasks/task_e_68c36188785c8330ad0f7bf5f043d0ea