### PR TITLE
Enable specialist delegation to MCP researcher

### DIFF
--- a/python-service/app/services/crewai/research_company/config/agents.yaml
+++ b/python-service/app/services/crewai/research_company/config/agents.yaml
@@ -30,11 +30,12 @@ financial_analyst:
     A detail-oriented analyst with expertise in reviewing financial reports, 
     market performance, and growth indicators. You translate complex numbers into 
     clear insights for job seekers concerned about company stability and future outlook.
+    Delegate work to coworker mcp_researcher when you need fresh web details.
   llm: "openai/gpt-5-mini"
   temperature: 0.2
   memory: true
   verbose: true
-  allow_delegation: false
+  allow_delegation: true
 
 culture_investigator:
   role: "Workplace Culture Investigator"
@@ -44,11 +45,12 @@ culture_investigator:
     diversity efforts, and workplace policies. You highlight what it’s *really like* 
     to work at the company, focusing on aspects job seekers care about such as 
     inclusion, work-life balance, and leadership support.
+    Delegate work to coworker mcp_researcher when you need fresh web details.
   llm: "openai/gpt-5-mini"
   temperature: 0.3
   memory: true
   verbose: true
-  allow_delegation: false
+  allow_delegation: true
 
 leadership_analyst:
   role: "Leadership and Reputation Analyst"
@@ -57,11 +59,12 @@ leadership_analyst:
     A reputation tracker skilled at analyzing leadership history, management styles, 
     and media coverage. You ensure job seekers understand how the company is 
     perceived internally by employees and externally by industry peers and the press.
+    Delegate work to coworker mcp_researcher when you need fresh web details.
   llm: "openai/gpt-5-mini"
   temperature: 0.2
   memory: true
   verbose: true
-  allow_delegation: false
+  allow_delegation: true
 
 career_growth_analyst:
   role: "Career Growth and Opportunities Analyst"
@@ -70,11 +73,12 @@ career_growth_analyst:
     A career coach at heart, you analyze job postings, career progression patterns, 
     training opportunities, and employee advancement stories to highlight how well 
     the company supports professional development.
+    Delegate work to coworker mcp_researcher when you need fresh web details.
   llm: "openai/gpt-5-mini"
   temperature: 0.2
   memory: true
   verbose: true
-  allow_delegation: false
+  allow_delegation: true
 
 mcp_researcher:
   role: "MCP Web Researcher"
@@ -88,7 +92,7 @@ mcp_researcher:
   temperature: 0.2
   memory: true
   verbose: true
-  allow_delegation: false
+  allow_delegation: true
   mcp_tools:
     - duckduckgo
 
@@ -99,11 +103,12 @@ report_writer:
     A skilled communicator with a talent for turning complex insights into clear, 
     engaging narratives. You excel at presenting company research in a way that 
     helps job seekers make informed career decisions.
+    Delegate work to coworker mcp_researcher when you need fresh web details.
   llm: "openai/gpt-5-mini"
   temperature: 0.4
   memory: true
   verbose: true
-  allow_delegation: false
+  allow_delegation: true
   constraints:
     - Write in a clear, candidate-friendly tone.
     - Do not add unsupported claims — only use validated research.

--- a/python-service/app/services/crewai/research_company/config/tasks.yaml
+++ b/python-service/app/services/crewai/research_company/config/tasks.yaml
@@ -2,8 +2,9 @@
 research_strategy_task:
   description: >
     Break down the research request into a strategy for investigating the target company.
-    Identify what information is needed across financials, culture, leadership, growth, 
+    Identify what information is needed across financials, culture, leadership, growth,
     and recent news. Delegate tasks to the appropriate specialist agents.
+    Remind specialists to use "Delegate work to coworker mcp_researcher" when they need fresh web details.
   expected_output: >
     A structured outline of research tasks to be completed by the analysts.
   agent: research_manager
@@ -21,9 +22,10 @@ latest_news_task:
 # 3. Financial analysis
 financial_analysis_task:
   description: >
-    Analyze the financial health of {company_name}. Check for indicators of stability or risk, 
+    Analyze the financial health of {company_name}. Check for indicators of stability or risk,
     such as recent funding, profitability, layoffs, or rapid expansion.
     Explain what these signals mean for a potential employee.
+    Delegate work to coworker mcp_researcher when you need fresh web details.
   expected_output: >
     A clear analysis of financial stability with 2-3 key metrics or events, and a plain-language
     explanation of what it means for job seekers.
@@ -33,9 +35,10 @@ financial_analysis_task:
 # 4. Workplace culture analysis
 culture_analysis_task:
   description: >
-    Research the workplace culture of {company_name}. Use employee reviews, 
-    workplace reputation, diversity and inclusion practices, and employee satisfaction indicators. 
+    Research the workplace culture of {company_name}. Use employee reviews,
+    workplace reputation, diversity and inclusion practices, and employee satisfaction indicators.
     Highlight strengths and weaknesses that matter to job seekers.
+    Delegate work to coworker mcp_researcher when you need fresh web details.
   expected_output: >
     A summary of workplace culture including 2-3 positive aspects and 2-3 potential red flags.
   context: [latest_news_task]
@@ -44,9 +47,10 @@ culture_analysis_task:
 # 5. Leadership and reputation analysis
 leadership_analysis_task:
   description: >
-    Research the leadership team at {company_name}. Identify CEO and senior leadership reputation, 
-    management style, and any notable controversies or praise in the media. 
+    Research the leadership team at {company_name}. Identify CEO and senior leadership reputation,
+    management style, and any notable controversies or praise in the media.
     Explain how leadership perception might affect job seekers.
+    Delegate work to coworker mcp_researcher when you need fresh web details.
   expected_output: >
     A profile of leadership reputation with key highlights (positive and negative)
     and a summary of how they impact workplace perception.
@@ -56,9 +60,10 @@ leadership_analysis_task:
 # 6. Career growth opportunities
 career_growth_task:
   description: >
-    Investigate career development and growth opportunities at {company_name}. 
-    Look into internal mobility, employee advancement, mentorship programs, training support, 
+    Investigate career development and growth opportunities at {company_name}.
+    Look into internal mobility, employee advancement, mentorship programs, training support,
     and job posting patterns.
+    Delegate work to coworker mcp_researcher when you need fresh web details.
   expected_output: >
     A summary of career growth opportunities with 2-3 examples of how employees
     can progress at this company.
@@ -89,6 +94,7 @@ final_report_task:
       - recent_news
       - overall_summary
     Make sure the JSON is valid and strictly follows the schema.
+    Delegate work to coworker mcp_researcher when you need fresh web details.
   expected_output: >
     A valid JSON object containing the research findings in the specified schema.
     Your final answer MUST be valid JSON.


### PR DESCRIPTION
## Summary
- Allow all research specialists to delegate and guide them to use "Delegate work to coworker mcp_researcher" for fresh web info
- Remind strategy and analysis tasks to delegate to mcp_researcher when up-to-date details are needed

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c47313e02c83308d0d239844f2bce6