### PR TITLE
feat: cache research company crew

### DIFF
--- a/python-service/app/services/crewai/research_company/crew.py
+++ b/python-service/app/services/crewai/research_company/crew.py
@@ -1,6 +1,13 @@
+from threading import Lock
+from typing import Optional
+
 from crewai import Agent, Task, Crew, Process
 from crewai.project import CrewBase, agent, task, crew
 from ..base import load_mcp_tools_sync
+
+
+_cached_crew: Optional[Crew] = None
+_crew_lock = Lock()
 
 @CrewBase
 class ResearchCompanyCrew:
@@ -80,5 +87,11 @@ class ResearchCompanyCrew:
         )
 
 
-def get_research_company_crew():
-    return ResearchCompanyCrew().crew()
+def get_research_company_crew() -> Crew:
+    global _cached_crew
+    if _cached_crew is None:
+        with _crew_lock:
+            if _cached_crew is None:
+                _cached_crew = ResearchCompanyCrew().crew()
+    assert _cached_crew is not None
+    return _cached_crew


### PR DESCRIPTION
## Summary
- cache the research company crew instance and reuse it on subsequent calls
- protect crew initialization with a thread-safe lock

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bleach')*

------
https://chatgpt.com/codex/tasks/task_e_68c485ecd00c83308ee9854d502a753a