### PR TITLE
Enable hierarchical CrewAI execution

### DIFF
--- a/python-service/app/services/crewai/job_posting_review/crew.py
+++ b/python-service/app/services/crewai/job_posting_review/crew.py
@@ -304,7 +304,8 @@ class MotivationalFanOutCrew:
             description=config["description"],
             expected_output=config["expected_output"],
             agent=self.builder_agent(),
-            async_execution=True  # Enable parallel execution
+            async_execution=True,  # Enable parallel execution
+            context=[self.helper_snapshot()]
         )
 
     @task
@@ -315,7 +316,8 @@ class MotivationalFanOutCrew:
             description=config["description"],
             expected_output=config["expected_output"],
             agent=self.maximizer_agent(),
-            async_execution=True  # Enable parallel execution
+            async_execution=True,  # Enable parallel execution
+            context=[self.helper_snapshot()]
         )
 
     @task
@@ -326,7 +328,8 @@ class MotivationalFanOutCrew:
             description=config["description"],
             expected_output=config["expected_output"],
             agent=self.harmonizer_agent(),
-            async_execution=True  # Enable parallel execution
+            async_execution=True,  # Enable parallel execution
+            context=[self.helper_snapshot()]
         )
 
     @task
@@ -337,7 +340,8 @@ class MotivationalFanOutCrew:
             description=config["description"],
             expected_output=config["expected_output"],
             agent=self.pathfinder_agent(),
-            async_execution=True  # Enable parallel execution
+            async_execution=True,  # Enable parallel execution
+            context=[self.helper_snapshot()]
         )
 
     @task
@@ -348,7 +352,8 @@ class MotivationalFanOutCrew:
             description=config["description"],
             expected_output=config["expected_output"],
             agent=self.adventurer_agent(),
-            async_execution=True  # Enable parallel execution
+            async_execution=True,  # Enable parallel execution
+            context=[self.helper_snapshot()]
         )
 
     # Helper tasks for advisory analysis
@@ -437,7 +442,12 @@ class MotivationalFanOutCrew:
             description=config["description"],
             expected_output=config["expected_output"],
             agent=self.data_analyst(),  # Use data_analyst agent for aggregation
-            async_execution=False
+            async_execution=False,
+            context=[
+                self.data_analyst_task(),
+                self.strategist_task(),
+                self.skeptic_task(),
+            ]
         )
 
     @crew
@@ -451,7 +461,7 @@ class MotivationalFanOutCrew:
         return Crew(
             agents=self.agents,
             tasks=self.tasks,
-            process=Process.sequential,  # Tasks will run in sequence but are designed for parallel evaluation
+            process=Process.hierarchical,
             verbose=True,
             memory=False  # Disable memory to avoid API key requirements
         )

--- a/python-service/app/services/crewai/job_review/crew.py
+++ b/python-service/app/services/crewai/job_review/crew.py
@@ -194,7 +194,7 @@ class JobReviewCrew:
             description=config["description"],
             expected_output=config["expected_output"],
             agent=agent_method(),
-            async_execution=False
+            async_execution=True
         )
     
     @task
@@ -211,7 +211,7 @@ class JobReviewCrew:
             description=config["description"],
             expected_output=config["expected_output"],
             agent=agent_method(),
-            async_execution=False
+            async_execution=True
         )
     
     @task
@@ -228,7 +228,7 @@ class JobReviewCrew:
             description=config["description"],
             expected_output=config["expected_output"],
             agent=agent_method(),
-            async_execution=False
+            async_execution=True
         )
     
     @crew
@@ -242,7 +242,7 @@ class JobReviewCrew:
         return Crew(
             agents=self.agents,
             tasks=self.tasks,
-            process=Process.sequential,
+            process=Process.hierarchical,
             verbose=True,
             memory=False  # Disable memory to avoid API key requirements
         )

--- a/python-service/app/services/crewai/personal_branding/crew.py
+++ b/python-service/app/services/crewai/personal_branding/crew.py
@@ -120,7 +120,7 @@ class PersonalBrandCrew:
         return Crew(
             agents=self.agents,  # Automatically collected by the @agent decorator
             tasks=self.tasks,    # Automatically collected by the @task decorator.
-            process=Process.sequential,
+            process=Process.hierarchical,
             verbose=True,
         )
 

--- a/python-service/app/services/crewai/research_company/crew.py
+++ b/python-service/app/services/crewai/research_company/crew.py
@@ -74,6 +74,7 @@ class ResearchCompanyCrew:
     def final_report_task(self) -> Task:
         return Task(
             config=self.tasks_config["final_report_task"],  # type: ignore[index]
+            context=[self.research_strategy_task()],
         )
 
     @crew
@@ -82,7 +83,7 @@ class ResearchCompanyCrew:
             agents=[self.research_manager(), self.financial_analyst(), self.culture_investigator(), self.leadership_analyst(), self.career_growth_analyst(), self.mcp_researcher(), self.report_writer()],
             tasks=[self.research_strategy_task(), self.final_report_task()],
             manager_agent=self.research_manager(),
-            process=Process.sequential,
+            process=Process.hierarchical,
             verbose=True,
         )
 


### PR DESCRIPTION
## Summary
- switch all crews to `Process.hierarchical` for parallel task execution
- add explicit task dependencies using `context` to preserve task order
- mark job review tasks as asynchronous for concurrent runs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bleach')*

------
https://chatgpt.com/codex/tasks/task_e_68c488da2b848330acfb1f4ccaf5b91f