### PR TITLE
Use typed CompanyReport schema in reports

### DIFF
--- a/python-service/app/api/v1/endpoints/company.py
+++ b/python-service/app/api/v1/endpoints/company.py
@@ -8,6 +8,6 @@ router = APIRouter(prefix="/company", tags=["Company Research"])
 async def company_report(request: CompanyRequest):
     try:
         report = generate_company_report(request.company_name)
-        return {"report": report}
+        return CompanyReportResponse(report=report)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/python-service/app/schemas/company.py
+++ b/python-service/app/schemas/company.py
@@ -1,7 +1,13 @@
 from pydantic import BaseModel
 
+
 class CompanyRequest(BaseModel):
     company_name: str
 
+
+class CompanyReport(BaseModel):
+    recent_news: list[str]
+
+
 class CompanyReportResponse(BaseModel):
-    report: dict  # since your writer returns JSON
+    report: CompanyReport

--- a/python-service/app/services/company_service.py
+++ b/python-service/app/services/company_service.py
@@ -1,13 +1,15 @@
 import json
 from app.services.crewai.research_company.crew import get_research_company_crew
+from app.schemas.company import CompanyReport
 
 
-def generate_company_report(company_name: str) -> dict:
+def generate_company_report(company_name: str) -> CompanyReport:
     """Run CrewAI and return parsed JSON report."""
     crew = get_research_company_crew()
     result = crew.kickoff(inputs={"company_name": company_name})
     raw_output = getattr(result, "raw", str(result))
     try:
-        return json.loads(raw_output)
+        data = json.loads(raw_output)
     except json.JSONDecodeError as exc:
         raise ValueError("Invalid JSON output from CrewAI") from exc
+    return CompanyReport(**data)

--- a/tests/test_company_news.py
+++ b/tests/test_company_news.py
@@ -33,7 +33,7 @@ def test_company_news(monkeypatch):
     )
 
     report = generate_company_report("SampleCo")
-    assert report["recent_news"] == [
+    assert report.recent_news == [
         "SampleCo announces new product line",
         "SampleCo secures major funding",
     ]


### PR DESCRIPTION
## Summary
- replace generic report dict with typed `CompanyReport` model
- return `CompanyReport` from service and API endpoint
- update tests for new schema

## Testing
- `pytest tests/test_company_news.py tests/test_company_report_invalid_json.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c48d78bba8833090ee964770ed4e05