### PR TITLE
Handle ValueError in company endpoint

### DIFF
--- a/python-service/app/api/v1/endpoints/company.py
+++ b/python-service/app/api/v1/endpoints/company.py
@@ -9,5 +9,7 @@ async def company_report(request: CompanyRequest):
     try:
         report = generate_company_report(request.company_name)
         return CompanyReportResponse(report=report)
+    except ValueError as e:
+        raise HTTPException(status_code=502, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- handle ValueError separately in company report endpoint returning HTTP 502

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c492bce2388330b74053dca6312f90