### PR TITLE
refactor: start company research with evidence gathering

### DIFF
--- a/python-service/app/services/crewai/research_company/config/tasks.yaml
+++ b/python-service/app/services/crewai/research_company/config/tasks.yaml
@@ -1,19 +1,3 @@
-# 1. Research strategy planning
-research_strategy_task:
-  description: >
-    Break down the research request into a strategy for investigating {{company_name}}.
-    Identify what information is needed across financials, culture, leadership, growth,
-    and recent news. Delegate tasks to the appropriate specialist agents.
-    Remind specialists to use "Delegate work to coworker mcp_researcher" when they need fresh web details.
-  expected_output: >
-    A structured outline of research tasks to be completed by the analysts,
-    explicitly referencing {{company_name}} in each task so that agents know the target.
-  agent: research_manager
-  inputs:
-    - company_name
-
-# removed 2-7 tasks as they are now handled by the research_manager
-
 # 8. Final report writing
 final_report_task:
   description: >

--- a/python-service/app/services/crewai/research_company/crew.py
+++ b/python-service/app/services/crewai/research_company/crew.py
@@ -65,23 +65,16 @@ class ResearchCompanyCrew:
         )
 
     @task
-    def research_strategy_task(self) -> Task:
-        return Task(
-            config=self.tasks_config["research_strategy_task"],  # type: ignore[index]
-        )
-
-    @task
     def final_report_task(self) -> Task:
         return Task(
             config=self.tasks_config["final_report_task"],  # type: ignore[index]
-            context=[self.research_strategy_task()],
         )
 
     @crew
     def crew(self) -> Crew:
         return Crew(
             agents=[self.research_manager(), self.financial_analyst(), self.culture_investigator(), self.leadership_analyst(), self.career_growth_analyst(), self.mcp_researcher(), self.report_writer()],
-            tasks=[self.research_strategy_task(), self.final_report_task()],
+            tasks=[self.final_report_task()],
             manager_agent=self.research_manager(),
             process=Process.hierarchical,
             verbose=True,


### PR DESCRIPTION
## Summary
- remove research strategy planning configuration
- begin company research crew directly with final report gathering

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'python_service', 'mcp', 'bleach')*

------
https://chatgpt.com/codex/tasks/task_e_68c496829fcc8330acd9795673ce7a5f