### PR TITLE
Handle non-JSON text in company report output

### DIFF
--- a/python-service/app/services/company_service.py
+++ b/python-service/app/services/company_service.py
@@ -1,4 +1,5 @@
 import json
+import re
 from app.services.crewai.research_company.crew import get_research_company_crew
 from app.schemas.company import CompanyReport
 
@@ -8,8 +9,11 @@ def generate_company_report(company_name: str) -> CompanyReport:
     crew = get_research_company_crew()
     result = crew.kickoff(inputs={"company_name": company_name})
     raw_output = getattr(result, "raw", str(result))
+    match = re.search(r"\{.*\}$", raw_output, re.S)
+    if not match:
+        raise ValueError("Invalid JSON output from CrewAI")
     try:
-        data = json.loads(raw_output)
+        data = json.loads(match.group())
     except json.JSONDecodeError as exc:
         raise ValueError("Invalid JSON output from CrewAI") from exc
     return CompanyReport(**data)


### PR DESCRIPTION
## Summary
- extract the final JSON block from CrewAI output when generating company reports
- raise a ValueError if CrewAI output lacks a valid JSON block

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c4982934088330aaecddd6aeae63b2