### PR TITLE
Enable concurrent company research tasks

### DIFF
--- a/python-service/app/services/crewai/research_company/crew.py
+++ b/python-service/app/services/crewai/research_company/crew.py
@@ -66,35 +66,40 @@ class ResearchCompanyCrew:
     def financial_analysis_task(self) -> Task:
         return Task(
             config=self.tasks_config["financial_analysis_task"],  # type: ignore[index]
-            agent=self.financial_analyst()
+            agent=self.financial_analyst(),
+            async_execution=True
         )
 
     @task
     def culture_investigation_task(self) -> Task:
         return Task(
             config=self.tasks_config["culture_investigation_task"],  # type: ignore[index]
-            agent=self.culture_investigator()
+            agent=self.culture_investigator(),
+            async_execution=True
         )
 
     @task
     def leadership_analysis_task(self) -> Task:
         return Task(
             config=self.tasks_config["leadership_analysis_task"],  # type: ignore[index]
-            agent=self.leadership_analyst()
+            agent=self.leadership_analyst(),
+            async_execution=True
         )
 
     @task
     def career_growth_analysis_task(self) -> Task:
         return Task(
             config=self.tasks_config["career_growth_analysis_task"],  # type: ignore[index]
-            agent=self.career_growth_analyst()
+            agent=self.career_growth_analyst(),
+            async_execution=True
         )
 
     @task
     def web_research_task(self) -> Task:
         return Task(
             config=self.tasks_config["web_research_task"],  # type: ignore[index]
-            agent=self.mcp_researcher()
+            agent=self.mcp_researcher(),
+            async_execution=True
         )
 
     @task
@@ -123,7 +128,7 @@ class ResearchCompanyCrew:
                 self.web_research_task(),
                 self.report_compilation_task()
             ],
-            process=Process.sequential,
+            process=Process.hierarchical,
             verbose=True,
         )
 


### PR DESCRIPTION
## Summary
- Run financial, culture, leadership, career growth, and web research tasks asynchronously.
- Assemble crew with hierarchical process for concurrent execution.
- Ensure final report task waits on other tasks by listing them in its context.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c4bc1d40508330889cc9736b344931