### PR TITLE
Refactor company research to share web data

### DIFF
--- a/python-service/app/services/crewai/research_company/config/tasks.yaml
+++ b/python-service/app/services/crewai/research_company/config/tasks.yaml
@@ -21,6 +21,7 @@ financial_analysis_task:
     }
   
   agent: financial_analyst
+  context: [web_research_task]
 
 culture_investigation_task:
   description: >
@@ -46,6 +47,7 @@ culture_investigation_task:
     }
     
   agent: culture_investigator
+  context: [web_research_task]
 
 leadership_analysis_task:
   description: >
@@ -71,6 +73,7 @@ leadership_analysis_task:
     }
     
   agent: leadership_analyst
+  context: [web_research_task]
 
 career_growth_analysis_task:
   description: >
@@ -96,6 +99,7 @@ career_growth_analysis_task:
     }
     
   agent: career_growth_analyst
+  context: [web_research_task]
 
 web_research_task:
   description: >

--- a/python-service/app/services/crewai/research_company/crew.py
+++ b/python-service/app/services/crewai/research_company/crew.py
@@ -25,28 +25,24 @@ class ResearchCompanyCrew:
     def financial_analyst(self) -> Agent:
         return Agent(
             config=self.agents_config["financial_analyst"],  # type: ignore[index]
-            tools=get_duckduckgo_tools()
         )
 
     @agent
     def culture_investigator(self) -> Agent:
         return Agent(
             config=self.agents_config["culture_investigator"],  # type: ignore[index]
-            tools=get_duckduckgo_tools()
         )
 
     @agent
     def leadership_analyst(self) -> Agent:
         return Agent(
             config=self.agents_config["leadership_analyst"],  # type: ignore[index]
-            tools=get_duckduckgo_tools()
         )
 
     @agent
     def career_growth_analyst(self) -> Agent:
         return Agent(
             config=self.agents_config["career_growth_analyst"],  # type: ignore[index]
-            tools=get_duckduckgo_tools()
         )
 
     @agent
@@ -121,11 +117,11 @@ class ResearchCompanyCrew:
                 self.report_writer()
             ],
             tasks=[
+                self.web_research_task(),
                 self.financial_analysis_task(),
                 self.culture_investigation_task(),
                 self.leadership_analysis_task(),
                 self.career_growth_analysis_task(),
-                self.web_research_task(),
                 self.report_compilation_task()
             ],
             process=Process.hierarchical,


### PR DESCRIPTION
## Summary
- Drop DuckDuckGo tools from financial, culture, leadership, and career growth agents
- Feed web_research_task results into all analysis tasks and run it first

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c4c406bf48833091a0f689b49236e3