### PR TITLE
Clarify recent_news format in final report task

### DIFF
--- a/python-service/app/services/crewai/research_company/config/tasks.yaml
+++ b/python-service/app/services/crewai/research_company/config/tasks.yaml
@@ -7,8 +7,9 @@ final_report_task:
       - workplace_culture
       - leadership_reputation
       - career_growth
-      - recent_news
+      - recent_news (array of strings like ['headline 1', 'headline 2'])
       - overall_summary
+    The recent_news field must be an array of plain strings; do not include objects.
     Ensure the JSON is valid and follows the schema.
   expected_output: >
     A valid JSON object containing the research findings in the specified schema.


### PR DESCRIPTION
## Summary
- Clarify final_report_task instructions that `recent_news` must be an array of plain strings (e.g., `['headline 1', 'headline 2']`), preventing object output.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bleach')*
- `pytest tests/test_company_news.py tests/test_company_report_invalid_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4c67531c08330ab1fd84ea110927f