### PR TITLE
Expand company report schema with detailed sections

### DIFF
--- a/python-service/app/schemas/company.py
+++ b/python-service/app/schemas/company.py
@@ -5,9 +5,82 @@ class CompanyRequest(BaseModel):
     company_name: str
 
 
+class FinancialHealth(BaseModel):
+    revenue_trends: str
+    profitability: str
+    funding_history: str
+    investor_information: str
+    market_performance: str
+    growth_indicators: str
+    financial_stability_score: str
+    key_financial_insights: list[str]
+
+
+class WorkplaceCulture(BaseModel):
+    company_values: str
+    employee_satisfaction: str
+    work_life_balance: str
+    diversity_inclusion: str
+    management_style: str
+    career_support: str
+    culture_score: str
+    cultural_highlights: list[str]
+    potential_concerns: list[str]
+
+
+class LeadershipReputation(BaseModel):
+    executive_team: str
+    leadership_style: str
+    industry_reputation: str
+    media_coverage: str
+    leadership_stability: str
+    vision_clarity: str
+    reputation_score: str
+    leadership_strengths: list[str]
+    reputation_risks: list[str]
+
+
+class CareerGrowth(BaseModel):
+    advancement_opportunities: str
+    training_programs: str
+    internal_mobility: str
+    mentorship_support: str
+    skill_development: str
+    promotion_patterns: str
+    growth_score: str
+    career_highlights: list[str]
+    growth_limitations: list[str]
+
+
+class RecentNews(BaseModel):
+    latest_developments: str
+    press_releases: str
+    acquisitions_partnerships: str
+    major_events: str
+    market_changes: str
+    recent_announcements: str
+    news_summary: str
+    key_updates: list[str]
+
+
+class OverallSummary(BaseModel):
+    recommendation_score: str
+    key_strengths: list[str]
+    potential_concerns: list[str]
+    best_fit_for: str
+    summary: str
+
+
 class CompanyReport(BaseModel):
-    recent_news: list[str]
+    company_name: str
+    financial_health: FinancialHealth
+    workplace_culture: WorkplaceCulture
+    leadership_reputation: LeadershipReputation
+    career_growth: CareerGrowth
+    recent_news: RecentNews
+    overall_summary: OverallSummary
 
 
 class CompanyReportResponse(BaseModel):
     report: CompanyReport
+

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -1,14 +1,14 @@
 import { 
-    JobApplication, Company, BaseResume, Status, CompanyPayload, JobApplicationPayload, 
-    BaseResumePayload, Contact, ContactPayload, Message, MessagePayload, Interview, 
-    InterviewPayload, LinkedInPost, LinkedInPostPayload, UserProfile, 
-    UserProfilePayload, LinkedInEngagement, PostResponse, PostResponsePayload, 
+    JobApplication, Company, BaseResume, Status, CompanyPayload, JobApplicationPayload,
+    BaseResumePayload, Contact, ContactPayload, Message, MessagePayload, Interview,
+    InterviewPayload, LinkedInPost, LinkedInPostPayload, UserProfile,
+    UserProfilePayload, LinkedInEngagement, PostResponse, PostResponsePayload,
     LinkedInEngagementPayload, StandardJobRole, StandardJobRolePayload, Resume, ResumeHeader, DateInfo, Education, Certification,
     StrategicNarrative, StrategicNarrativePayload, Offer, OfferPayload,
     BragBankEntry, BragBankEntryPayload, SkillTrend, SkillTrendPayload,
     Sprint, SprintAction, CreateSprintPayload, SprintActionPayload, ApplicationQuestion,
     SiteSchedule, SiteDetails, SiteSchedulePayload,
-    CollectionInfo, UploadResponse
+    CollectionInfo, UploadResponse, CompanyReport
 } from '../types';
 import { API_BASE_URL, USER_ID, FASTAPI_BASE_URL } from '../constants';
 import { v4 as uuidv4 } from 'uuid';
@@ -389,6 +389,16 @@ export const updateCompany = async (companyId: string, companyData: Partial<Comp
     
     // Re-fetch the full object for consistency
     return getCompany(companyId);
+};
+
+export const getCompanyReport = async (companyName: string): Promise<CompanyReport> => {
+    const response = await fetch(`${FASTAPI_BASE_URL}/company/report`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ company_name: companyName }),
+    });
+    const data = await handleResponse(response);
+    return data.report as CompanyReport;
 };
 
 // --- Resumes ---

--- a/tests/test_company_news.py
+++ b/tests/test_company_news.py
@@ -25,7 +25,69 @@ def test_company_news(monkeypatch):
         def kickoff(self, inputs):
             tool = MockDuckDuckGoTool()
             news = tool.search(inputs["company_name"])
-            return json.dumps({"recent_news": news})
+            return json.dumps({
+                "company_name": "SampleCo",
+                "financial_health": {
+                    "revenue_trends": "",
+                    "profitability": "",
+                    "funding_history": "",
+                    "investor_information": "",
+                    "market_performance": "",
+                    "growth_indicators": "",
+                    "financial_stability_score": "",
+                    "key_financial_insights": [],
+                },
+                "workplace_culture": {
+                    "company_values": "",
+                    "employee_satisfaction": "",
+                    "work_life_balance": "",
+                    "diversity_inclusion": "",
+                    "management_style": "",
+                    "career_support": "",
+                    "culture_score": "",
+                    "cultural_highlights": [],
+                    "potential_concerns": [],
+                },
+                "leadership_reputation": {
+                    "executive_team": "",
+                    "leadership_style": "",
+                    "industry_reputation": "",
+                    "media_coverage": "",
+                    "leadership_stability": "",
+                    "vision_clarity": "",
+                    "reputation_score": "",
+                    "leadership_strengths": [],
+                    "reputation_risks": [],
+                },
+                "career_growth": {
+                    "advancement_opportunities": "",
+                    "training_programs": "",
+                    "internal_mobility": "",
+                    "mentorship_support": "",
+                    "skill_development": "",
+                    "promotion_patterns": "",
+                    "growth_score": "",
+                    "career_highlights": [],
+                    "growth_limitations": [],
+                },
+                "recent_news": {
+                    "latest_developments": "",
+                    "press_releases": "",
+                    "acquisitions_partnerships": "",
+                    "major_events": "",
+                    "market_changes": "",
+                    "recent_announcements": "",
+                    "news_summary": "",
+                    "key_updates": news,
+                },
+                "overall_summary": {
+                    "recommendation_score": "",
+                    "key_strengths": [],
+                    "potential_concerns": [],
+                    "best_fit_for": "",
+                    "summary": "",
+                },
+            })
 
     monkeypatch.setattr(
         "app.services.company_service.get_research_company_crew",
@@ -33,7 +95,7 @@ def test_company_news(monkeypatch):
     )
 
     report = generate_company_report("SampleCo")
-    assert report.recent_news == [
+    assert report.recent_news.key_updates == [
         "SampleCo announces new product line",
         "SampleCo secures major funding",
     ]

--- a/types.ts
+++ b/types.ts
@@ -123,6 +123,83 @@ export interface CompanyInfoResult {
   industry?: InfoField;
 }
 
+// Company research report
+export interface FinancialHealth {
+  revenue_trends: string;
+  profitability: string;
+  funding_history: string;
+  investor_information: string;
+  market_performance: string;
+  growth_indicators: string;
+  financial_stability_score: string;
+  key_financial_insights: string[];
+}
+
+export interface WorkplaceCulture {
+  company_values: string;
+  employee_satisfaction: string;
+  work_life_balance: string;
+  diversity_inclusion: string;
+  management_style: string;
+  career_support: string;
+  culture_score: string;
+  cultural_highlights: string[];
+  potential_concerns: string[];
+}
+
+export interface LeadershipReputation {
+  executive_team: string;
+  leadership_style: string;
+  industry_reputation: string;
+  media_coverage: string;
+  leadership_stability: string;
+  vision_clarity: string;
+  reputation_score: string;
+  leadership_strengths: string[];
+  reputation_risks: string[];
+}
+
+export interface CareerGrowth {
+  advancement_opportunities: string;
+  training_programs: string;
+  internal_mobility: string;
+  mentorship_support: string;
+  skill_development: string;
+  promotion_patterns: string;
+  growth_score: string;
+  career_highlights: string[];
+  growth_limitations: string[];
+}
+
+export interface RecentNews {
+  latest_developments: string;
+  press_releases: string;
+  acquisitions_partnerships: string;
+  major_events: string;
+  market_changes: string;
+  recent_announcements: string;
+  news_summary: string;
+  key_updates: string[];
+}
+
+export interface OverallSummary {
+  recommendation_score: string;
+  key_strengths: string[];
+  potential_concerns: string[];
+  best_fit_for: string;
+  summary: string;
+}
+
+export interface CompanyReport {
+  company_name: string;
+  financial_health: FinancialHealth;
+  workplace_culture: WorkplaceCulture;
+  leadership_reputation: LeadershipReputation;
+  career_growth: CareerGrowth;
+  recent_news: RecentNews;
+  overall_summary: OverallSummary;
+}
+
 // Based on the 'companies' table
 export interface Company {
   company_id: string; // uuid in DB


### PR DESCRIPTION
## Summary
- extend `CompanyReport` with detailed sections for finance, culture, leadership, growth, news and summary
- add TypeScript interfaces and API helper for company reports
- adjust tests for new `CompanyReport` structure

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build`
- `pytest tests/test_company_news.py tests/test_company_report_invalid_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4e94c44cc83308d4822da330e065c