### PR TITLE
Wrap MCP tool args for executor compatibility

### DIFF
--- a/python-service/app/services/crewai/README.md
+++ b/python-service/app/services/crewai/README.md
@@ -120,6 +120,19 @@ execution_sequence:
   - quality_assessment
 ```
 
+### MCP Tool Structure
+
+MCP tools accessed through this service expect input arguments formatted as a
+JSON-like payload containing both `args` and `kwargs` keys. Positional
+arguments are wrapped automatically by `MCPDynamicTool` into:
+
+```python
+{"args": <original_args>, "kwargs": {}}
+```
+
+When invoking tools directly, ensure to supply this structure so the MCP
+Gateway can forward requests correctly.
+
 ## Best Practices
 
 ### CrewBase Implementation

--- a/python-service/app/services/crewai/base.py
+++ b/python-service/app/services/crewai/base.py
@@ -18,7 +18,12 @@ from crewai.tools import BaseTool
 
 
 class MCPDynamicTool(BaseTool):
-    """Lightweight wrapper around MCP tools for CrewAI compatibility."""
+    """Lightweight wrapper around MCP tools for CrewAI compatibility.
+
+    MCP tools expect arguments in the form ``{"args": ..., "kwargs": {}}``.
+    This wrapper translates CrewAI's positional arguments into that structure
+    before delegating execution to the underlying MCP executor.
+    """
 
     name: str
     description: str = ""
@@ -26,7 +31,10 @@ class MCPDynamicTool(BaseTool):
     parameters: Dict[str, Any] | None = None
 
     def _run(self, *args: Any, **kwargs: Any) -> Any:  # type: ignore[override]
-        return self.executor(*args, **kwargs)
+        if args:
+            arg_payload = args[0] if len(args) == 1 else list(args)
+            return self.executor(args=arg_payload, kwargs={})
+        return self.executor(**kwargs)
 
     async def _arun(self, *args: Any, **kwargs: Any) -> Any:  # type: ignore[override]
         raise NotImplementedError("MCPDynamicTool does not support async execution")


### PR DESCRIPTION
## Summary
- ensure MCP tools receive args and kwargs payloads by wrapping positional arguments
- document expected MCP tool argument structure in crewai README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bleach'; dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fcb360b0833096f564c7a45e568e