### PR TITLE
feat: add company report schema and endpoint

### DIFF
--- a/python-service/app/api/router.py
+++ b/python-service/app/api/router.py
@@ -6,6 +6,7 @@ from app.api.v1.endpoints.jobspy import router as jobspy_router
 from app.api.v1.endpoints.scheduler import router as scheduler_router
 from app.api.v1.endpoints.crewai_personal_brand import router as crewai_personal_brand_router
 from app.api.v1.endpoints.chroma import router as chroma_router
+from app.api.v1.endpoints.company_report import router as company_report_router
 
 api_router = APIRouter()
 
@@ -14,5 +15,6 @@ api_router.include_router(jobspy_router, prefix="/jobs", tags=["jobs", "scraping
 api_router.include_router(scheduler_router, prefix="/scheduler", tags=["scheduler"])
 api_router.include_router(crewai_personal_brand_router, tags=["job-review", "crewai"])
 api_router.include_router(chroma_router, tags=["chroma", "vector-database"])
+api_router.include_router(company_report_router, tags=["company-report"])
 
 __all__ = ["api_router"]

--- a/python-service/app/api/v1/endpoints/company_report.py
+++ b/python-service/app/api/v1/endpoints/company_report.py
@@ -1,0 +1,14 @@
+"""Endpoints for company report generation."""
+from fastapi import APIRouter
+
+from ....schemas.responses import StandardResponse, create_success_response
+from ....services.company_report import get_company_report
+
+router = APIRouter()
+
+
+@router.get("/companies/{company_name}/report", response_model=StandardResponse)
+async def fetch_company_report(company_name: str) -> StandardResponse:
+    """Return a company report for the given company name."""
+    report = await get_company_report(company_name)
+    return create_success_response(data=report)

--- a/python-service/app/schemas/__init__.py
+++ b/python-service/app/schemas/__init__.py
@@ -3,3 +3,4 @@
 from .jobspy import ScrapedJob  # noqa: F401
 from .responses import StandardResponse, create_success_response, create_error_response  # noqa: F401
 from .evaluations import PersonaEvaluation, Decision, EvaluationSummary  # noqa: F401
+from .company_report import CompanyReport  # noqa: F401

--- a/python-service/app/schemas/company_report.py
+++ b/python-service/app/schemas/company_report.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class FinancialHealth(BaseModel):
+    """Financial status of a company."""
+    revenue: Optional[str] = ""
+    profitability: Optional[str] = ""
+    funding_status: Optional[str] = ""
+    notable_investors: Optional[List[str]] = Field(default_factory=list)
+
+
+class WorkplaceCulture(BaseModel):
+    """Workplace culture aspects."""
+    employee_satisfaction: Optional[str] = ""
+    work_life_balance: Optional[str] = ""
+    benefits: Optional[List[str]] = Field(default_factory=list)
+
+
+class LeadershipReputation(BaseModel):
+    """Leadership reputation details."""
+    ceo_rating: Optional[str] = ""
+    leadership_changes: Optional[str] = ""
+    public_perception: Optional[str] = ""
+
+
+class CareerGrowth(BaseModel):
+    """Career growth opportunities."""
+    promotion_opportunities: Optional[str] = ""
+    learning_programs: Optional[List[str]] = Field(default_factory=list)
+    alumni_success: Optional[str] = ""
+
+
+class CompanyReport(BaseModel):
+    """Comprehensive report about a company."""
+    company_name: str
+    financial_health: FinancialHealth = Field(default_factory=FinancialHealth)
+    workplace_culture: WorkplaceCulture = Field(default_factory=WorkplaceCulture)
+    leadership_reputation: LeadershipReputation = Field(default_factory=LeadershipReputation)
+    career_growth: CareerGrowth = Field(default_factory=CareerGrowth)

--- a/python-service/app/services/company_report.py
+++ b/python-service/app/services/company_report.py
@@ -1,0 +1,16 @@
+"""Service utilities for generating company reports."""
+from __future__ import annotations
+from typing import Any
+
+from ..schemas.company_report import CompanyReport
+
+
+async def get_company_report(company_name: str) -> CompanyReport:
+    """Generate a company report.
+
+    This is a placeholder implementation that returns empty sections
+    with sensible defaults. Future implementations can populate data from
+    external services or databases.
+    """
+    # In a real implementation, gather data from various sources here.
+    return CompanyReport(company_name=company_name)

--- a/python-service/tests/test_company_report_schema.py
+++ b/python-service/tests/test_company_report_schema.py
@@ -1,0 +1,23 @@
+from app.schemas.company_report import CompanyReport
+
+
+def test_company_report_defaults():
+    report = CompanyReport(company_name="Test Corp")
+    assert report.financial_health.funding_status == ""
+    assert report.financial_health.notable_investors == []
+    assert report.workplace_culture.benefits == []
+    assert report.leadership_reputation.public_perception == ""
+    assert report.career_growth.learning_programs == []
+
+
+def test_company_report_partial_payload():
+    payload = {
+        "company_name": "Example Inc",
+        "financial_health": {"funding_status": "Series A"},
+        "career_growth": {"promotion_opportunities": "Fast"},
+    }
+    report = CompanyReport(**payload)
+    assert report.financial_health.funding_status == "Series A"
+    # Unprovided fields fall back to defaults
+    assert report.financial_health.notable_investors == []
+    assert report.career_growth.learning_programs == []


### PR DESCRIPTION
## Summary
- define nested CompanyReport schema with defaults
- expose company report endpoint and service
- test CompanyReport validation with partial payloads

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/tests/test_company_report_schema.py -q`
- `pytest python-service/tests -q` *(fails: AssertionError: 'ChromaDB connection failed')*


------
https://chatgpt.com/codex/tasks/task_e_68c5c2736f3483308e221dca543ee914