### PR TITLE
feat: introduce React Query hooks

### DIFF
--- a/components/DashboardView.tsx
+++ b/components/DashboardView.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { JobApplication, Contact, Message, LinkedInPost, UserProfile, Prompt, StrategicNarrative, LinkedInEngagement, BaseResume, StrategicNarrativePayload, SkillGapAnalysisResult, NarrativeSynthesisResult, SkillTrendPayload, AiFocusItem, Sprint, SkillTrend, Company, PromptContext, SprintActionPayload } from '../types';
 import * as geminiService from '../services/geminiService';
-import * as apiService from '../services/apiService';
 import { LoadingSpinner, CheckBadgeIcon, ClockIcon, StrategyIcon, RocketLaunchIcon, MagnifyingGlassPlusIcon, XCircleIcon, NetworkingIcon, SparklesIcon } from './IconComponents';
 import { SkillGapAnalysisModal } from './SkillGapAnalysisModal';
 import { CatalyzePathModal } from './CatalyzePathModal';

--- a/components/ResumeInputStep.tsx
+++ b/components/ResumeInputStep.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { ArrowRightIcon, LoadingSpinner } from './IconComponents';
 import { BaseResume, Resume, Prompt, KeywordsResult, UserProfile, ResumeHeader, StrategicNarrative } from '../types';
 import { BLANK_RESUME_CONTENT } from '../mockData';
-import * as apiService from '../services/apiService';
+import { useGetResumeContent } from '../hooks/apiHooks';
 import { ensureUniqueAchievementIds } from '../utils/resume';
 
 interface SelectResumeStepProps {
@@ -19,6 +19,7 @@ interface SelectResumeStepProps {
 
 export const SelectResumeStep = ({ baseResumes, onNext, isLoading, keywords, userProfile, applicationNarrative }: SelectResumeStepProps): React.ReactNode => {
     const [selectedResumeId, setSelectedResumeId] = useState<string>('');
+    const { refetch: fetchResumeContent } = useGetResumeContent(selectedResumeId, false);
     const [customResumeJson, setCustomResumeJson] = useState<string>(JSON.stringify(BLANK_RESUME_CONTENT, null, 2));
     const [error, setError] = useState<string | null>(null);
 
@@ -46,8 +47,8 @@ export const SelectResumeStep = ({ baseResumes, onNext, isLoading, keywords, use
         } else {
             const foundResume = baseResumes.find(r => r.resume_id.toString() === selectedResumeId);
             if(foundResume) {
-                const fullContent = await apiService.getResumeContent(foundResume.resume_id);
-                 if (userProfile) {
+                const { data: fullContent } = await fetchResumeContent();
+                 if (userProfile && fullContent) {
                     const header: ResumeHeader = {
                         ...fullContent.header, // Keep existing header data
                         // Override with profile data if available
@@ -62,7 +63,7 @@ export const SelectResumeStep = ({ baseResumes, onNext, isLoading, keywords, use
                     };
                     resumeToProcess = { ...fullContent, header };
                 } else {
-                    setError("User profile not loaded, cannot proceed.");
+                setError("User profile not loaded, cannot proceed.");
                     return;
                 }
             }

--- a/hooks/apiHooks.ts
+++ b/hooks/apiHooks.ts
@@ -1,0 +1,73 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as apiService from '../services/apiService';
+import { Company, BaseResume, Resume, SiteSchedule, SiteDetails, SiteSchedulePayload } from '../types';
+
+export const useGetCompanies = () => {
+  return useQuery<Company[], Error>({
+    queryKey: ['companies'],
+    queryFn: apiService.getCompanies,
+  });
+};
+
+export const useGetBaseResumes = () => {
+  return useQuery<BaseResume[], Error>({
+    queryKey: ['baseResumes'],
+    queryFn: apiService.getBaseResumes,
+  });
+};
+
+export const useGetResumeContent = (resumeId: string, enabled = true) => {
+  return useQuery<Resume, Error>({
+    queryKey: ['resumeContent', resumeId],
+    queryFn: () => apiService.getResumeContent(resumeId),
+    enabled,
+  });
+};
+
+export const useCheckPostgrestHealth = () => {
+  return useMutation(apiService.checkPostgrestHealth);
+};
+
+export const useCheckFastApiHealth = () => {
+  return useMutation(apiService.checkFastApiHealth);
+};
+
+export const useGetSiteSchedules = () => {
+  return useQuery<SiteSchedule[], Error>({
+    queryKey: ['siteSchedules'],
+    queryFn: apiService.getSiteSchedules,
+  });
+};
+
+export const useGetJobSites = () => {
+  return useQuery<SiteDetails[], Error>({
+    queryKey: ['jobSites'],
+    queryFn: apiService.getJobSites,
+  });
+};
+
+export const useCreateSiteSchedule = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: apiService.createSiteSchedule,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['siteSchedules'] }),
+  });
+};
+
+export const useUpdateSiteSchedule = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ scheduleId, payload }: { scheduleId: string; payload: SiteSchedulePayload }) =>
+      apiService.updateSiteSchedule(scheduleId, payload),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['siteSchedules'] }),
+  });
+};
+
+export const useDeleteSiteSchedule = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (scheduleId: string) => apiService.deleteSiteSchedule(scheduleId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['siteSchedules'] }),
+  });
+};
+

--- a/index.tsx
+++ b/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
 
 const rootElement = document.getElementById('root');
@@ -7,9 +8,12 @@ if (!rootElement) {
   throw new Error("Could not find root element to mount to");
 }
 
+const queryClient = new QueryClient();
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "6.23.1",
+    "@tanstack/react-query": "^5.59.3",
     "@google/genai": "^1.7.0",
     "docx": "^8.5.0",
     "file-saver": "2.0.5",


### PR DESCRIPTION
## Summary
- add React Query and wrap app with `QueryClientProvider`
- create reusable hooks for API access and site scheduling
- refactor select components to consume hooks over direct `apiService` calls

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "@tanstack/react-query"; package install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c3f3451c83308e84478a74e17ba6