### PR TITLE
Expand company report schema with optional fields

### DIFF
--- a/python-service/app/schemas/company_report.py
+++ b/python-service/app/schemas/company_report.py
@@ -1,39 +1,68 @@
 from __future__ import annotations
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from typing import List, Optional
 
 
 class FinancialHealth(BaseModel):
     """Financial status of a company."""
+
+    model_config = ConfigDict(extra="allow")
+
     revenue: Optional[str] = ""
     profitability: Optional[str] = ""
     funding_status: Optional[str] = ""
     notable_investors: Optional[List[str]] = Field(default_factory=list)
+    funding_events: Optional[List[str]] = Field(default_factory=list)
+    risk_factors: Optional[List[str]] = Field(default_factory=list)
 
 
 class WorkplaceCulture(BaseModel):
     """Workplace culture aspects."""
+
+    model_config = ConfigDict(extra="allow")
+
     employee_satisfaction: Optional[str] = ""
     work_life_balance: Optional[str] = ""
     benefits: Optional[List[str]] = Field(default_factory=list)
+    company_values_emphasized: Optional[List[str]] = Field(default_factory=list)
+    key_culture_signals: Optional[List[str]] = Field(default_factory=list)
+    potential_culture_risks: Optional[List[str]] = Field(default_factory=list)
 
 
 class LeadershipReputation(BaseModel):
     """Leadership reputation details."""
+
+    model_config = ConfigDict(extra="allow")
+
     ceo_rating: Optional[str] = ""
     leadership_changes: Optional[str] = ""
     public_perception: Optional[str] = ""
+    executive_team_overview: Optional[str] = ""
+    recent_news_summary: Optional[str] = ""
+    overall_reputation: Optional[str] = ""
+    potential_leadership_strengths_to_verify: Optional[str] = ""
+    potential_reputation_risks_to_verify: Optional[str] = ""
 
 
 class CareerGrowth(BaseModel):
     """Career growth opportunities."""
+
+    model_config = ConfigDict(extra="allow")
+
     promotion_opportunities: Optional[str] = ""
     learning_programs: Optional[List[str]] = Field(default_factory=list)
     alumni_success: Optional[str] = ""
+    training_and_support: Optional[str] = ""
+    employee_sentiment_on_growth: Optional[str] = ""
+    positive_growth_signals: Optional[List[str]] = Field(default_factory=list)
+    potential_growth_risks: Optional[List[str]] = Field(default_factory=list)
 
 
 class CompanyReport(BaseModel):
     """Comprehensive report about a company."""
+
+    model_config = ConfigDict(extra="allow")
+
     company_name: str
     financial_health: FinancialHealth = Field(default_factory=FinancialHealth)
     workplace_culture: WorkplaceCulture = Field(default_factory=WorkplaceCulture)

--- a/python-service/tests/test_company_report_schema.py
+++ b/python-service/tests/test_company_report_schema.py
@@ -5,9 +5,30 @@ def test_company_report_defaults():
     report = CompanyReport(company_name="Test Corp")
     assert report.financial_health.funding_status == ""
     assert report.financial_health.notable_investors == []
+    assert report.financial_health.funding_events == []
+    assert report.financial_health.risk_factors == []
+
     assert report.workplace_culture.benefits == []
+    assert report.workplace_culture.company_values_emphasized == []
+    assert report.workplace_culture.key_culture_signals == []
+    assert report.workplace_culture.potential_culture_risks == []
+
     assert report.leadership_reputation.public_perception == ""
+    assert report.leadership_reputation.executive_team_overview == ""
+    assert report.leadership_reputation.recent_news_summary == ""
+    assert report.leadership_reputation.overall_reputation == ""
+    assert (
+        report.leadership_reputation.potential_leadership_strengths_to_verify == ""
+    )
+    assert (
+        report.leadership_reputation.potential_reputation_risks_to_verify == ""
+    )
+
     assert report.career_growth.learning_programs == []
+    assert report.career_growth.training_and_support == ""
+    assert report.career_growth.employee_sentiment_on_growth == ""
+    assert report.career_growth.positive_growth_signals == []
+    assert report.career_growth.potential_growth_risks == []
 
 
 def test_company_report_partial_payload():
@@ -20,4 +41,7 @@ def test_company_report_partial_payload():
     assert report.financial_health.funding_status == "Series A"
     # Unprovided fields fall back to defaults
     assert report.financial_health.notable_investors == []
+    assert report.financial_health.funding_events == []
+    assert report.workplace_culture.company_values_emphasized == []
     assert report.career_growth.learning_programs == []
+    assert report.career_growth.positive_growth_signals == []


### PR DESCRIPTION
## Summary
- extend company report sub-models with additional optional fields and allow extra keys
- test defaults for new company report fields when payloads are partial

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/tests/test_company_report_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c7b672e48330aa96785da6dbcc63