### PR TITLE
feat: allow population by field names in company schemas

### DIFF
--- a/python-service/app/schemas/company.py
+++ b/python-service/app/schemas/company.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from typing import Union
 
 
@@ -7,34 +7,82 @@ class CompanyRequest(BaseModel):
 
 
 class FinancialHealth(BaseModel):
-    funding_events: str = Field(..., alias="funding_status")
+    model_config = ConfigDict(populate_by_name=True)
+
+    funding_events: str = Field(
+        ..., validation_alias="funding_status", serialization_alias="funding_status"
+    )
     notable_investors: str
     financial_trend: str
-    risk_flag: str = Field(..., alias="risk_factors")
+    risk_flag: str = Field(
+        ..., validation_alias="risk_factors", serialization_alias="risk_factors"
+    )
 
 
 class WorkplaceCulture(BaseModel):
-    company_values: list[str] = Field(..., alias="company_values_emphasized")
+    model_config = ConfigDict(populate_by_name=True)
+
+    company_values: list[str] = Field(
+        ..., validation_alias="company_values_emphasized",
+        serialization_alias="company_values_emphasized",
+    )
     employee_sentiment: str
     work_life_balance: str
-    culture_signals: list[str] = Field(..., alias="key_culture_signals")
-    risk_flag: str = Field(..., alias="potential_culture_risks")
+    culture_signals: list[str] = Field(
+        ..., validation_alias="key_culture_signals",
+        serialization_alias="key_culture_signals",
+    )
+    risk_flag: str = Field(
+        ..., validation_alias="potential_culture_risks",
+        serialization_alias="potential_culture_risks",
+    )
 
 
 class LeadershipReputation(BaseModel):
-    executive_team: Union[list[str], str] = Field(..., alias="executive_team_overview")
-    recent_news: str = Field(..., alias="recent_news_summary")
-    leadership_reputation: str = Field(..., alias="overall_reputation")
-    leadership_strengths: Union[list[str], str] = Field(..., alias="potential_leadership_strengths_to_verify")
-    reputation_risks: Union[list[str], str] = Field(..., alias="potential_reputation_risks_to_verify")
+    model_config = ConfigDict(populate_by_name=True)
+
+    executive_team: Union[list[str], str] = Field(
+        ..., validation_alias="executive_team_overview",
+        serialization_alias="executive_team_overview",
+    )
+    recent_news: str = Field(
+        ..., validation_alias="recent_news_summary",
+        serialization_alias="recent_news_summary",
+    )
+    leadership_reputation: str = Field(
+        ..., validation_alias="overall_reputation",
+        serialization_alias="overall_reputation",
+    )
+    leadership_strengths: Union[list[str], str] = Field(
+        ..., validation_alias="potential_leadership_strengths_to_verify",
+        serialization_alias="potential_leadership_strengths_to_verify",
+    )
+    reputation_risks: Union[list[str], str] = Field(
+        ..., validation_alias="potential_reputation_risks_to_verify",
+        serialization_alias="potential_reputation_risks_to_verify",
+    )
 
 
 class CareerGrowth(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     advancement_opportunities: str
-    training_support: str = Field(..., alias="training_and_support")
-    employee_sentiment: str = Field(..., alias="employee_sentiment_on_growth")
-    growth_signals: list[str] = Field(..., alias="positive_growth_signals")
-    growth_risks: list[str] = Field(..., alias="potential_growth_risks")
+    training_support: str = Field(
+        ..., validation_alias="training_and_support",
+        serialization_alias="training_and_support",
+    )
+    employee_sentiment: str = Field(
+        ..., validation_alias="employee_sentiment_on_growth",
+        serialization_alias="employee_sentiment_on_growth",
+    )
+    growth_signals: list[str] = Field(
+        ..., validation_alias="positive_growth_signals",
+        serialization_alias="positive_growth_signals",
+    )
+    growth_risks: list[str] = Field(
+        ..., validation_alias="potential_growth_risks",
+        serialization_alias="potential_growth_risks",
+    )
 
 
 class RecentNews(BaseModel):
@@ -57,6 +105,8 @@ class OverallSummary(BaseModel):
 
 
 class CompanyReport(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     company_name: str
     financial_health: FinancialHealth
     workplace_culture: WorkplaceCulture


### PR DESCRIPTION
## Summary
- allow population of company schemas by field name with `populate_by_name`
- replace deprecated `alias` usage with `validation_alias` and `serialization_alias`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c5c92602d48330b4e37dd11b6a32cf