### PR TITLE
Handle multiple notable investors in company schema

### DIFF
--- a/python-service/app/schemas/company.py
+++ b/python-service/app/schemas/company.py
@@ -12,7 +12,7 @@ class FinancialHealth(BaseModel):
     funding_events: str = Field(
         ..., validation_alias="funding_status", serialization_alias="funding_status"
     )
-    notable_investors: str
+    notable_investors: list[str]
     financial_trend: str
     risk_flag: str = Field(
         ..., validation_alias="risk_factors", serialization_alias="risk_factors"


### PR DESCRIPTION
## Summary
- allow `FinancialHealth.notable_investors` to accept multiple entries by using `list[str]`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c5ca7abe9c8330b4d43cadd78795a5