### PR TITLE
Fix CrewAI tool import path

### DIFF
--- a/python-service/app/services/crewai/tools/__init__.py
+++ b/python-service/app/services/crewai/tools/__init__.py
@@ -6,7 +6,7 @@ from .chroma_search import (
     chroma_list_collections,
     chroma_search_across_collections,
 )
-from crewai_tools import tool
+from crewai.tools import tool
 
 
 def get_postgres_tool() -> PostgresQueryTool:

--- a/python-service/app/services/crewai/tools/chroma_search.py
+++ b/python-service/app/services/crewai/tools/chroma_search.py
@@ -1,7 +1,7 @@
 """ChromaDB search tools for CrewAI following 0.186.1 best practices."""
 
 from typing import List, Optional, Dict, Any
-from crewai_tools import tool
+from crewai.tools import tool
 from ...infrastructure.chroma import get_chroma_client
 
 


### PR DESCRIPTION
## Summary
- fix CrewAI tool decorator import path in chroma search tools

## Testing
- `python -m py_compile python-service/app/services/crewai/tools/chroma_search.py python-service/app/services/crewai/tools/__init__.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c5e67f08448330a72523365f205f51