### PR TITLE
Improve CrewAI job review parsing

### DIFF
--- a/python-service/app/api/v1/endpoints/job_posting_review.py
+++ b/python-service/app/api/v1/endpoints/job_posting_review.py
@@ -101,17 +101,16 @@ async def analyze_job_posting_simple(job_posting: Union[str, Dict[str, Any]]):
         Analysis results from the CrewAI crew
     """
     try:
-        # Use the crew directly for simpler interface
-        crew = get_job_posting_review_crew()
-        
-        # Convert job posting to string for the crew input
-        job_posting_str = job_posting if isinstance(job_posting, str) else str(job_posting)
-        
-        # Run the crew with the job posting
-        result = crew.kickoff(inputs={"job_posting": job_posting_str})
-        
+        job_data = {"raw_text": job_posting} if isinstance(job_posting, str) else job_posting
+
+        result = run_crew(
+            job_posting_data=job_data,
+            options={},
+            correlation_id=None,
+        )
+
         return create_success_response(
-            data={"result": str(result), "crew_output": True},
+            data=result,
             message="Job posting analysis completed successfully"
         )
     

--- a/python-service/app/services/crewai/AGENTS.md
+++ b/python-service/app/services/crewai/AGENTS.md
@@ -626,6 +626,12 @@ export LOG_LEVEL=DEBUG
 
 This provides detailed execution logs without making external API calls.
 
+### Result Parsing
+
+- Use `parse_crew_result` to extract JSON from `crew.kickoff` outputs.
+- Parsed data must include `final`, `personas`, and at least one score field. Additional metrics are surfaced under a `data` key while `final.rationale` stays concise.
+- Text heuristics are used only when parsing fails.
+
 ---
 
 **Remember**: This AGENT.md file is a living document that must evolve with the codebase. Keep it updated, accurate, and actionable for future AI agents and developers working with CrewAI implementations.

--- a/python-service/app/services/crewai/job_posting_review/AGENTS.md
+++ b/python-service/app/services/crewai/job_posting_review/AGENTS.md
@@ -167,9 +167,10 @@ inputs = {
 - Size limits enforced to prevent token bloat (1.5 KB helper snapshot limit)
 
 **JSON Parsing**:
-- Primary: Extract JSON object matching expected schema from task output
-- Also accepts simplified `{job_title, company, recommendation, ...}` payloads. These fields are preserved under `data` and `recommendation`/`overall_fit` map to boolean `final.recommend`.
-- Fallback: Text parsing for boolean recommendation and reason extraction
+- Primary: Extract JSON object matching expected schema from task output.
+- Validator: Parsed object must include `final`, `personas`, and at least one key containing `score`.
+- Metrics: Non-standard keys (including score fields) are moved under a separate `data` object; `final.rationale` is trimmed to a concise summary.
+- Fallback: Text parsing for boolean recommendation and reason extraction when JSON parsing fails.
 - Error: Return `{recommend: false, reason: "insufficient signal", notes: ["task execution failed"]}`
 
 ## YAML Binding Rules

--- a/python-service/app/services/crewai/parser.py
+++ b/python-service/app/services/crewai/parser.py
@@ -1,0 +1,67 @@
+import json
+import re
+from typing import Any, Dict
+
+
+def _find_json_block(text: str) -> str:
+    """Extract the first JSON object from a text blob.
+
+    Prefers fenced code blocks but falls back to first JSON-like braces.
+    Raises ValueError if no JSON is found.
+    """
+    fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if fence_match:
+        return fence_match.group(1)
+
+    brace_match = re.search(r"(\{.*\})", text, re.DOTALL)
+    if brace_match:
+        return brace_match.group(1)
+
+    raise ValueError("No JSON payload found in crew output")
+
+
+def _has_score_field(obj: Any) -> bool:
+    """Recursively check for any key containing 'score'."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if "score" in key.lower():
+                return True
+            if _has_score_field(value):
+                return True
+    elif isinstance(obj, list):
+        return any(_has_score_field(item) for item in obj)
+    return False
+
+
+def parse_crew_result(raw_output: str) -> Dict[str, Any]:
+    """Parse and validate CrewAI output.
+
+    Args:
+        raw_output: Raw string from `crew.kickoff`.
+
+    Returns:
+        Structured dictionary with required keys and separate metrics under `data`.
+
+    Raises:
+        ValueError: If JSON is missing or required fields are absent.
+    """
+    json_str = _find_json_block(raw_output)
+    data = json.loads(json_str)
+
+    if "final" not in data or "personas" not in data:
+        raise ValueError("Missing required keys in crew output")
+    if not _has_score_field(data):
+        raise ValueError("No score fields present in crew output")
+
+    final = data.get("final", {})
+    rationale = str(final.get("rationale", ""))
+    summary = rationale.split("\n")[0][:200]
+    final["rationale"] = summary
+
+    standard_keys = {"final", "personas", "tradeoffs", "actions", "sources"}
+    metrics = {k: v for k, v in data.items() if k not in standard_keys}
+
+    structured = {k: data[k] for k in data if k in standard_keys}
+    structured["data"] = metrics
+    structured["final"] = final
+    return structured

--- a/python-service/tests/crewai/test_job_posting_review_response.py
+++ b/python-service/tests/crewai/test_job_posting_review_response.py
@@ -35,10 +35,15 @@ def test_run_crew_returns_job_details():
     }
 
     crew_output = {
+        "final": {
+            "recommend": True,
+            "rationale": "Strong match across metrics",
+            "confidence": "high",
+        },
+        "personas": [],
         "job_title": "Software Engineer",
         "company": "Acme",
-        "recommendation": "green-light",
-        "overall_fit": "high",
+        "fit_score": 0.9,
     }
 
     mock_crew = Mock()
@@ -52,5 +57,5 @@ def test_run_crew_returns_job_details():
 
     assert result["data"]["job_title"] == "Software Engineer"
     assert result["data"]["company"] == "Acme"
-    assert result["data"]["recommendation"] == "green-light"
+    assert result["data"]["fit_score"] == 0.9
 


### PR DESCRIPTION
## Summary
- parse crew.kickoff output with new `parse_crew_result` helper that validates required keys and score fields
- have job posting review service and endpoint use structured results with concise `final.rationale`
- document structured JSON parsing in AGENTS guidelines and add test coverage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/tests/crewai/test_job_posting_review_response.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5f9ec1ce08330a994644e687f9f82