### PR TITLE
Enforce structured crew output schema

### DIFF
--- a/python-service/app/services/crewai/AGENTS.md
+++ b/python-service/app/services/crewai/AGENTS.md
@@ -629,7 +629,7 @@ This provides detailed execution logs without making external API calls.
 ### Result Parsing
 
 - Use `parse_crew_result` to extract JSON from `crew.kickoff` outputs.
-- Parsed data must include `final`, `personas`, and at least one score field. Additional metrics are surfaced under a `data` key while `final.rationale` stays concise.
+- Parsed data must include `final`, `personas`, `tradeoffs`, `actions`, `sources`, and at least one score field. Additional metrics are surfaced under a `data` key while `final.rationale` stays concise.
 - Text heuristics are used only when parsing fails.
 
 ---

--- a/python-service/app/services/crewai/job_posting_review/AGENTS.md
+++ b/python-service/app/services/crewai/job_posting_review/AGENTS.md
@@ -168,7 +168,7 @@ inputs = {
 
 **JSON Parsing**:
 - Primary: Extract JSON object matching expected schema from task output.
-- Validator: Parsed object must include `final`, `personas`, and at least one key containing `score`.
+- Validator: Parsed object must include `final`, `personas`, `tradeoffs`, `actions`, `sources`, and at least one key containing `score`.
 - Metrics: Non-standard keys (including score fields) are moved under a separate `data` object; `final.rationale` is trimmed to a concise summary.
 - Fallback: Text parsing for boolean recommendation and reason extraction when JSON parsing fails.
 - Error: Return `{recommend: false, reason: "insufficient signal", notes: ["task execution failed"]}`

--- a/python-service/app/services/crewai/job_posting_review/config/tasks.yaml
+++ b/python-service/app/services/crewai/job_posting_review/config/tasks.yaml
@@ -46,14 +46,29 @@ brand_match_task:
 
 orchestration_task:
   description: >
-    Manage the pipeline for {{job_posting}}: 
-    1. Run intake_task → pre_filter_task. 
-    2. If {{pre_filter_task.output}} is "reject", stop. 
-    3. If {{pre_filter_task.output}} is "pass", run quick_fit_task. 
-    4. If {{quick_fit_task.output.quick_recommendation}} is "review_deeper", run brand_match_task. 
+    Manage the pipeline for {{job_posting}}:
+    1. Run intake_task → pre_filter_task.
+    2. If {{pre_filter_task.output}} is "reject", stop.
+    3. If {{pre_filter_task.output}} is "pass", run quick_fit_task.
+    4. If {{quick_fit_task.output.quick_recommendation}} is "review_deeper", run brand_match_task.
     5. Provide a final recommendation: "green-light" or "reject" with reasons.
+
+    The final response **must** be a JSON object containing only these top-level keys:
+    `final`, `personas`, `tradeoffs`, `actions`, `sources`, and any additional metrics
+    grouped under a `data` object. If any mandatory key is missing, reply exactly with
+    `{"error": "missing mandatory keys"}`.
+
+    Example schema:
+    {
+      "final": {"recommend": boolean, "rationale": string, "confidence": string},
+      "personas": [{"id": string, "recommend": boolean, "reason": string}],
+      "tradeoffs": [string],
+      "actions": [string],
+      "sources": [string],
+      "data": {"example_metric": number}
+    }
   expected_output: >
-    A final JSON object with all relevant results and the decision.
+    Final JSON object adhering to the schema above. Reject any output missing required keys.
   agent: managing_agent
   input:
     job_posting: "{{job_posting}}"

--- a/python-service/app/services/crewai/parser.py
+++ b/python-service/app/services/crewai/parser.py
@@ -48,8 +48,10 @@ def parse_crew_result(raw_output: str) -> Dict[str, Any]:
     json_str = _find_json_block(raw_output)
     data = json.loads(json_str)
 
-    if "final" not in data or "personas" not in data:
-        raise ValueError("Missing required keys in crew output")
+    required_keys = {"final", "personas", "tradeoffs", "actions", "sources"}
+    missing = [k for k in required_keys if k not in data]
+    if missing:
+        raise ValueError(f"Missing required keys in crew output: {', '.join(missing)}")
     if not _has_score_field(data):
         raise ValueError("No score fields present in crew output")
 

--- a/python-service/tests/crewai/test_job_posting_review_response.py
+++ b/python-service/tests/crewai/test_job_posting_review_response.py
@@ -41,6 +41,9 @@ def test_run_crew_returns_job_details():
             "confidence": "high",
         },
         "personas": [],
+        "tradeoffs": ["high_competition"],
+        "actions": ["reach_out_recruiter"],
+        "sources": ["job_posting"],
         "job_title": "Software Engineer",
         "company": "Acme",
         "fit_score": 0.9,
@@ -58,4 +61,6 @@ def test_run_crew_returns_job_details():
     assert result["data"]["job_title"] == "Software Engineer"
     assert result["data"]["company"] == "Acme"
     assert result["data"]["fit_score"] == 0.9
+    for key in ["final", "personas", "tradeoffs", "actions", "sources"]:
+        assert key in result
 

--- a/python-service/tests/crewai/test_parse_crew_result_keys.py
+++ b/python-service/tests/crewai/test_parse_crew_result_keys.py
@@ -1,0 +1,20 @@
+import json
+import os
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from app.services.crewai.parser import parse_crew_result
+
+
+def test_parse_crew_result_requires_mandatory_keys():
+    payload = json.dumps({
+        "final": {"recommend": True, "rationale": "ok", "confidence": "high"},
+        "personas": [],
+        "tradeoffs": [],
+        "actions": [],
+        "fit_score": 0.5
+    })
+    with pytest.raises(ValueError):
+        parse_crew_result(payload)


### PR DESCRIPTION
## Summary
- require orchestration task to emit JSON with `final`, `personas`, `tradeoffs`, `actions`, and `sources` keys
- validate these mandatory fields in `parse_crew_result`
- add tests for structured crew results and missing-key rejection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/tests/crewai/test_job_posting_review_response.py python-service/tests/crewai/test_parse_crew_result_keys.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5fb915ed88330ae8c2bcf39f50b49