### PR TITLE
refactor: add explicit job review orchestration

### DIFF
--- a/python-service/app/schemas/__init__.py
+++ b/python-service/app/schemas/__init__.py
@@ -3,3 +3,4 @@
 from .jobspy import ScrapedJob  # noqa: F401
 from .responses import StandardResponse, create_success_response, create_error_response  # noqa: F401
 from .evaluations import PersonaEvaluation, Decision, EvaluationSummary  # noqa: F401
+from .job_posting_review import JobPostingReviewOutput  # noqa: F401

--- a/python-service/app/schemas/job_posting_review.py
+++ b/python-service/app/schemas/job_posting_review.py
@@ -1,0 +1,12 @@
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel
+
+
+class JobPostingReviewOutput(BaseModel):
+    """Model for orchestrated job posting review output."""
+
+    job_intake: Dict[str, Any]
+    pre_filter: Dict[str, Any]
+    quick_fit: Optional[Dict[str, Any]] = None
+    brand_match: Optional[Dict[str, Any]] = None

--- a/python-service/app/services/crewai/job_posting_review/AGENTS.md
+++ b/python-service/app/services/crewai/job_posting_review/AGENTS.md
@@ -2,6 +2,23 @@
 
 **Purpose**: Orchestrates the motivational evaluator fan-out system using CrewAI multi-agent architecture with YAML-first design and optional helper agent insights.
 
+## Update: Explicit Python Orchestration
+
+This crew now runs its evaluation pipeline directly in Python via the
+`run_orchestration` method in `crew.py`. The YAML files still define all
+agents and tasks, but the `managing_agent` and `orchestration_task` entries
+are retained only for backward compatibility and are not registered in the
+crew. The sequence executed is:
+
+1. `intake_task` – parse raw job posting text
+2. `pre_filter_task` – early rejection check (terminates on `status="reject"`)
+3. `quick_fit_task`
+4. `brand_match_task`
+
+The method returns a JSON object validated by the `JobPostingReviewOutput`
+Pydantic model with keys `job_intake`, `pre_filter`, `quick_fit`, and
+`brand_match`.
+
 **Entrypoints**:
 - `run_crew(job_posting_data, options, correlation_id)` → main entry for FastAPI routes executing motivational fan-out
 - `MotivationalFanOutCrew.motivational_fanout()` → YAML-driven crew executing helper snapshot + five parallel evaluations  


### PR DESCRIPTION
## Summary
- orchestrate job posting review sequentially in Python, bypassing managing agent
- validate final outputs using new JobPostingReviewOutput Pydantic model
- update tests and documentation for new orchestration flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/crewai/test_job_posting_review_response.py::test_run_crew_returns_job_details -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6587646188330855df8edfe8cb0b3