### PR TITLE
Fix job posting review orchestration to use crew tasks

### DIFF
--- a/python-service/app/services/crewai/job_posting_review/AGENTS.md
+++ b/python-service/app/services/crewai/job_posting_review/AGENTS.md
@@ -15,7 +15,9 @@ crew. The sequence executed is:
 3. `quick_fit_task`
 4. `brand_match_task`
 
-The method returns a JSON object validated by the `JobPostingReviewOutput`
+The orchestration method constructs a fresh crew instance (`crew = self.crew()`) and
+retrieves task objects from `crew.tasks` so each agent is bound to the crew before
+sequential execution. The method returns a JSON object validated by the `JobPostingReviewOutput`
 Pydantic model with keys `job_intake`, `pre_filter`, `quick_fit`, and
 `brand_match`.
 


### PR DESCRIPTION
## Summary
- ensure JobPostingReviewCrew creates a crew in run_orchestration and executes tasks from crew.tasks
- document crew instantiation in job_posting_review AGENTS guide

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/tests/crewai/test_job_posting_review_response.py::test_run_crew_returns_job_details -q`


------
https://chatgpt.com/codex/tasks/task_e_68c65afd430c8330928ee6a1bdd56727