### PR TITLE
Refactor brand-driven crew to use structured Chroma tools

### DIFF
--- a/python-service/app/services/crewai/brand_driven_job_search/config/agents.yaml
+++ b/python-service/app/services/crewai/brand_driven_job_search/config/agents.yaml
@@ -14,8 +14,6 @@ brand_query_generator:
   max_iter: 2
   verbose: true
   allow_delegation: false
-  tools:
-    - chroma_search_tool
   constraints:
     - "Generate diverse queries covering all brand dimensions"
     - "Ensure queries are specific enough to find relevant roles"
@@ -60,8 +58,6 @@ brand_alignment_scorer:
   max_iter: 2
   verbose: true
   allow_delegation: false
-  tools:
-    - chroma_search_tool
   constraints:
     - "Score jobs on multiple brand alignment dimensions"
     - "Provide clear rationale for alignment scores"

--- a/python-service/app/services/crewai/brand_driven_job_search/crew.py
+++ b/python-service/app/services/crewai/brand_driven_job_search/crew.py
@@ -13,7 +13,7 @@ from crewai.project import CrewBase, agent, task, crew
 from loguru import logger
 
 from ..base import load_mcp_tools_sync
-from ..tools.chroma_search import chroma_search_tool
+from ..tools.chroma_search import get_career_brand_tools
 from .brand_search import brand_search_helper
 
 _cached_crew: Optional[Crew] = None
@@ -46,11 +46,11 @@ class BrandDrivenJobSearchCrew:
             linkedin_tool_names = ["search_jobs"]
             self._linkedin_tools = load_mcp_tools_sync(linkedin_tool_names)
             
-            # ChromaDB tool is available as a function
-            self._chroma_tools = [chroma_search_tool]
-            
+            # Career brand search tools for querying ChromaDB content
+            self._chroma_tools = get_career_brand_tools()
+
             logger.info(f"Loaded {len(self._linkedin_tools)} LinkedIn tools and {len(self._chroma_tools)} ChromaDB tools")
-            
+
         except Exception as e:
             logger.warning(f"Failed to load tools: {e}")
             self._linkedin_tools = []


### PR DESCRIPTION
## Summary
- update the brand search helper to query Chroma through the shared manager and return structured document metadata
- load career-brand search tools through the new `get_career_brand_tools` helper and drop legacy YAML tool names
- expand the crew and helper tests with dummy tool stubs and anyio-backed async coverage for the new tool API

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest python-service/tests/services/test_brand_driven_job_search_crew.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc80062bb88330a1a5a07195a630b0