### PR TITLE
Normalize LinkedIn job search crew output handling

### DIFF
--- a/python-service/app/api/v1/endpoints/linkedin_job_search.py
+++ b/python-service/app/api/v1/endpoints/linkedin_job_search.py
@@ -7,7 +7,10 @@ from loguru import logger
 
 from ....schemas.responses import StandardResponse, create_success_response, create_error_response
 from ....schemas.linkedin_job_search import LinkedInJobSearchRequest, LinkedInJobSearchResponse
-from ....services.crewai.linkedin_job_search.crew import get_linkedin_job_search_crew
+from ....services.crewai.linkedin_job_search.crew import (
+    get_linkedin_job_search_crew,
+    normalize_linkedin_job_search_output,
+)
 
 router = APIRouter(prefix="/linkedin-job-search", tags=["LinkedIn Job Search"])
 
@@ -79,14 +82,15 @@ async def search_linkedin_jobs(request: LinkedInJobSearchRequest):
         # Execute LinkedIn job search crew
         crew = get_linkedin_job_search_crew()
         result = crew.kickoff(inputs=search_params)
-        
+        result = normalize_linkedin_job_search_output(result)
+
         # Check if search was successful
         if not result.get("success", False):
             return create_error_response(
                 error="LinkedIn job search failed",
                 message=result.get("error", "Unknown error occurred")
             )
-        
+
         # Transform result to response schema
         response_data = LinkedInJobSearchResponse(
             success=result.get("success", True),

--- a/python-service/tests/api/test_linkedin_job_search_api.py
+++ b/python-service/tests/api/test_linkedin_job_search_api.py
@@ -1,11 +1,13 @@
 """
 API tests for LinkedIn Job Search endpoints.
 """
+import json
 import os
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/testdb")
@@ -47,7 +49,7 @@ class TestLinkedInJobSearchAPI:
             "duplicates_removed": 0,
             "consolidation_metadata": {}
         }
-        mock_crew.kickoff.return_value = mock_result
+        mock_crew.kickoff.return_value = SimpleNamespace(raw=json.dumps(mock_result))
         
         # Test API call
         request_data = {
@@ -86,7 +88,7 @@ class TestLinkedInJobSearchAPI:
             "consolidated_jobs": [],
             "total_jobs": 0
         }
-        mock_crew.kickoff.return_value = mock_result
+        mock_crew.kickoff.return_value = SimpleNamespace(raw=json.dumps(mock_result))
         
         request_data = {
             "keywords": "data scientist",

--- a/python-service/tests/services/test_linkedin_job_search_crew.py
+++ b/python-service/tests/services/test_linkedin_job_search_crew.py
@@ -1,5 +1,7 @@
 """Unit tests for LinkedIn Job Search Crew helpers."""
+import json
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/testdb")
@@ -34,7 +36,8 @@ class TestLinkedInJobSearchCrew:
         """run_linkedin_job_search should pass readable criteria to the crew."""
         mock_crew = MagicMock()
         mock_get_crew.return_value = mock_crew
-        mock_crew.kickoff.return_value = {"success": True}
+        mock_payload = {"success": True}
+        mock_crew.kickoff.return_value = SimpleNamespace(raw=json.dumps(mock_payload))
 
         result = run_linkedin_job_search(
             keywords="python developer",
@@ -66,7 +69,8 @@ class TestLinkedInJobSearchCrew:
         """Optional filters should be omitted from inputs and description when missing."""
         mock_crew = MagicMock()
         mock_get_crew.return_value = mock_crew
-        mock_crew.kickoff.return_value = {"success": True}
+        mock_payload = {"success": True}
+        mock_crew.kickoff.return_value = SimpleNamespace(raw=json.dumps(mock_payload))
 
         run_linkedin_job_search(keywords="data scientist", remote=False, limit=25)
 


### PR DESCRIPTION
## Summary
- normalize LinkedIn job search crew outputs so the API can work with CrewOutput payloads
- update the crew runner to return normalized data and refresh tests to mock raw JSON results

## Testing
- pytest tests/api/test_linkedin_job_search_api.py tests/services/test_linkedin_job_search_crew.py
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68ccc19e8f2483308f184d0a3036d010