### PR TITLE
Handle LinkedIn job search report payloads as successful

### DIFF
--- a/python-service/app/api/v1/endpoints/linkedin_job_search.py
+++ b/python-service/app/api/v1/endpoints/linkedin_job_search.py
@@ -85,10 +85,20 @@ async def search_linkedin_jobs(request: LinkedInJobSearchRequest):
         result = normalize_linkedin_job_search_output(result)
 
         # Check if search was successful
-        if not result.get("success", False):
+        success_flag = result.get("success")
+        raw_error = result.get("error")
+
+        normalized_error = None
+        if isinstance(raw_error, str):
+            stripped_error = raw_error.strip()
+            normalized_error = stripped_error if stripped_error else None
+        elif raw_error:
+            normalized_error = str(raw_error)
+
+        if success_flag is False or normalized_error:
             return create_error_response(
                 error="LinkedIn job search failed",
-                message=result.get("error", "Unknown error occurred")
+                message=normalized_error or "Unknown error occurred"
             )
 
         # Transform result to response schema

--- a/python-service/tests/services/test_linkedin_job_search_crew.py
+++ b/python-service/tests/services/test_linkedin_job_search_crew.py
@@ -9,6 +9,7 @@ os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/tes
 from app.services.crewai.linkedin_job_search.crew import (  # noqa: E402
     LinkedInJobSearchCrew,
     get_linkedin_job_search_crew,
+    normalize_linkedin_job_search_output,
     run_linkedin_job_search,
 )
 
@@ -81,3 +82,27 @@ class TestLinkedInJobSearchCrew:
             "limit": 25,
             "search_criteria": "Keywords: 'data scientist'; Limit: 25",
         }
+
+    def test_normalize_injects_success_for_report_schema(self):
+        """Report-style payloads should receive a success flag."""
+        report_payload = {
+            "executive_summary": "Key findings",
+            "priority_opportunities": [
+                {
+                    "rank": 1,
+                    "job_title": "Lead Developer",
+                    "company_name": "DevSolutions",
+                    "rationale": "Matches leadership experience",
+                    "next_steps": ["Apply via referral"]
+                }
+            ],
+            "networking_action_plan": ["Connect with alumni"],
+            "timeline_recommendations": ["Week 1: outreach"],
+            "success_metrics": ["Attend 2 networking events"],
+            "linkedin_profile_optimizations": ["Refresh about section"]
+        }
+
+        normalized = normalize_linkedin_job_search_output(report_payload)
+
+        assert normalized["success"] is True
+        assert normalized["executive_summary"] == "Key findings"


### PR DESCRIPTION
## Summary
- treat LinkedIn job search runs as successful when no explicit failure flag is returned and surface trimmed error messages when present
- ensure crew output normalization injects a success flag when the structured report schema is detected
- add API and service tests covering report-only payloads so the endpoint now returns HTTP 200 success

## Testing
- pytest python-service/tests/api/test_linkedin_job_search_api.py python-service/tests/services/test_linkedin_job_search_crew.py
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68cd995f67388330882ea5ce2ed417bc