### PR TITLE
Ensure LinkedIn cookie is passed to MCP gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,7 @@ MCP_GATEWAY_URL=http://mcp-gateway:8811
 MCP_GATEWAY_ENABLED=true
 
 # LinkedIn MCP Server configuration
+# LINKEDIN_COOKIE must match your active LinkedIn session cookie so the MCP gateway can forward it to the LinkedIn MCP server.
 LINKEDIN_EMAIL=your_linkedin_email@example.com
 LINKEDIN_PASSWORD=your_linkedin_password
 LINKEDIN_COOKIE=your_linkedin_session_cookie

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,6 +253,9 @@ services:
       - --servers=duckduckgo,linkedin-mcp-server
       - --transport=sse
       - --port=8811
+    environment:
+      # Ensure the gateway can forward LinkedIn secrets to docker-run commands
+      LINKEDIN_COOKIE: ${LINKEDIN_COOKIE}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:


### PR DESCRIPTION
## Summary
- map the LINKEDIN_COOKIE secret into the mcp-gateway container so its docker-run commands inherit the cookie value
- document the LinkedIn cookie requirement in the environment template used for deployments

## Testing
- docker compose config *(fails: docker is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cde123699c8330b044281e4ab521db