### PR TITLE
Load MCP servers from config for SSE handling

### DIFF
--- a/python-service/test_mcp_integration.py
+++ b/python-service/test_mcp_integration.py
@@ -31,7 +31,18 @@ async def test_mcp_gateway_connection():
         async with get_mcp_adapter(gateway_url) as adapter:
             tools = adapter.get_available_tools()
             logger.info(f"Connected successfully! Available tools: {list(tools.keys())}")
-            
+
+            available_servers = adapter.get_available_servers()
+            logger.info(
+                f"Connected successfully! Available servers: {available_servers}"
+            )
+
+            normalized_servers = [server.lower() for server in available_servers]
+            assert "duckduckgo" in normalized_servers, "DuckDuckGo server not detected"
+            assert any(
+                "linkedin" in server for server in normalized_servers
+            ), "LinkedIn server not detected"
+
             # Test DuckDuckGo tools specifically
             duckduckgo_tools = adapter.get_duckduckgo_tools()
             logger.info(f"DuckDuckGo tools: {len(duckduckgo_tools)}")


### PR DESCRIPTION
## Summary
- load the SSE server list from the MCP configuration file instead of hard-coding DuckDuckGo
- retain transport metadata when connecting to each server and expose the connected server names through the adapter
- extend the integration test to assert that both DuckDuckGo and LinkedIn servers are available

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68d03ff1f88c8330b6a2267f0b3263bd