### PR TITLE
Return DuckDuckGo tool list from MCP adapter

### DIFF
--- a/python-service/app/services/mcp_adapter.py
+++ b/python-service/app/services/mcp_adapter.py
@@ -376,6 +376,8 @@ class MCPServerAdapter:
                 # Convert MCP tool format to CrewAI tool format
                 crewai_tool = self._convert_mcp_tool_to_crewai(tool_name, tool_config)
                 duckduckgo_tools.append(crewai_tool)
+
+        return duckduckgo_tools
                 
     def get_linkedin_tools(self) -> List[Dict[str, Any]]:
         """


### PR DESCRIPTION
## Summary
- ensure `get_duckduckgo_tools` in the MCP adapter returns the collected tool definitions so consumers receive a proper list

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68d045f00b288330b8f694872505e8cb