### PR TITLE
Ensure MCP adapter loads config from python-service root

### DIFF
--- a/python-service/app/services/mcp_adapter.py
+++ b/python-service/app/services/mcp_adapter.py
@@ -42,31 +42,39 @@ class MCPServerAdapter:
 
     def _load_configured_servers(self) -> Dict[str, Dict[str, Any]]:
         """Load MCP server definitions from configuration."""
-        config_path = Path(__file__).resolve().parents[3] / "mcp-config" / "servers.json"
+        module_path = Path(__file__).resolve()
+        python_service_root = module_path.parents[2]
 
-        try:
-            with config_path.open("r", encoding="utf-8") as config_file:
-                config_data = json.load(config_file)
+        candidate_paths = [python_service_root / "mcp-config" / "servers.json"]
 
-            servers = config_data.get("servers", {})
-            if isinstance(servers, dict):
-                return servers
+        container_config_path = Path("/app") / "mcp-config" / "servers.json"
+        if container_config_path not in candidate_paths:
+            candidate_paths.append(container_config_path)
 
-            logger.warning(
-                f"Invalid servers configuration structure in {config_path}: expected a mapping"
-            )
-        except FileNotFoundError:
-            logger.warning(
-                f"Servers configuration file not found at {config_path}."
-            )
-        except json.JSONDecodeError as exc:
-            logger.warning(
-                f"Failed to parse servers configuration at {config_path}: {exc}"
-            )
-        except Exception as exc:
-            logger.warning(
-                f"Unexpected error loading servers configuration from {config_path}: {exc}"
-            )
+        for config_path in candidate_paths:
+            try:
+                with config_path.open("r", encoding="utf-8") as config_file:
+                    config_data = json.load(config_file)
+
+                servers = config_data.get("servers", {})
+                if isinstance(servers, dict):
+                    return servers
+
+                logger.warning(
+                    f"Invalid servers configuration structure in {config_path}: expected a mapping"
+                )
+            except FileNotFoundError:
+                logger.warning(
+                    f"Servers configuration file not found at {config_path}."
+                )
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    f"Failed to parse servers configuration at {config_path}: {exc}"
+                )
+            except Exception as exc:
+                logger.warning(
+                    f"Unexpected error loading servers configuration from {config_path}: {exc}"
+                )
 
         return {}
         


### PR DESCRIPTION
## Summary
- update MCPServerAdapter to resolve the servers.json path from the python-service root and fall back to /app
- add a unit test that simulates the container path resolution and verifies both configured servers are loaded
- run the MCP integration script against a stubbed gateway to confirm both server definitions are logged

## Testing
- pytest tests/services/test_mcp_adapter.py
- python -m py_compile $(git ls-files '*.py')
- python python-service/test_mcp_integration.py (against stubbed gateway)


------
https://chatgpt.com/codex/tasks/task_e_68d05374965c8330951620ba81c663e2