### PR TITLE
Normalize SSE session query parsing

### DIFF
--- a/python-service/app/services/mcp_adapter.py
+++ b/python-service/app/services/mcp_adapter.py
@@ -182,7 +182,11 @@ class MCPServerAdapter:
                     redirect_url = redirect_location
 
                 parsed = urlparse(redirect_url)
-                session_id = parse_qs(parsed.query).get("sessionid", [None])[0]
+                query_params = parse_qs(parsed.query)
+                normalized_query = {
+                    key.lower(): value for key, value in query_params.items()
+                }
+                session_id = normalized_query.get("sessionid", [None])[0]
                 if not session_id:
                     raise ValueError(
                         f"Missing session identifier in SSE redirect for server '{server_name}'"


### PR DESCRIPTION
## Summary
- normalize SSE redirect query parameter names so session IDs are captured regardless of casing
- extend the MCP adapter SSE test to cover mixed-case sessionId redirects and confirm successful connections

## Testing
- pytest tests/services/test_mcp_adapter.py
- python -m py_compile $(git ls-files '*.py')
- python python-service/test_mcp_integration.py *(fails: MCP gateway unavailable in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d055ba93a48330850130aa0989c3bf