### PR TITLE
Add MCP gateway diagnostics for health checks

### DIFF
--- a/python-service/app/api/v1/endpoints/linkedin_job_search.py
+++ b/python-service/app/api/v1/endpoints/linkedin_job_search.py
@@ -146,7 +146,8 @@ async def health_check():
                 "linkedin_tools_found": connection_status.get("linkedin_tools", []),
                 "expected_tools_found": connection_status.get("expected_tools_found", []),
                 "missing_tools": connection_status.get("missing_tools", []),
-                "gateway_url": connection_status.get("gateway_url", "unknown")
+                "gateway_url": connection_status.get("gateway_url", "unknown"),
+                "diagnostics": connection_status.get("diagnostics", {})
             }
         }
         

--- a/python-service/app/api/v1/endpoints/linkedin_recommendations.py
+++ b/python-service/app/api/v1/endpoints/linkedin_recommendations.py
@@ -97,7 +97,8 @@ async def health_check():
                 "linkedin_tools_found": connection_status.get("linkedin_tools", []),
                 "expected_tools_found": connection_status.get("expected_tools_found", []),
                 "missing_tools": connection_status.get("missing_tools", []),
-                "gateway_url": connection_status.get("gateway_url", "unknown")
+                "gateway_url": connection_status.get("gateway_url", "unknown"),
+                "diagnostics": connection_status.get("diagnostics", {})
             }
         }
         


### PR DESCRIPTION
## Summary
- add a gateway connectivity diagnostic helper to the MCP adapter and log the results when connections fail
- enrich the LinkedIn MCP connection test with diagnostic output and expose it through LinkedIn health endpoints

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68d09dac91a88330b232b3faf3a6caef