### PR TITLE
Harden SSE session cookie handling

### DIFF
--- a/python-service/app/services/mcp_adapter.py
+++ b/python-service/app/services/mcp_adapter.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import json
 import socket
+from collections import OrderedDict
 from contextlib import asynccontextmanager, suppress
 from http.cookies import SimpleCookie
 from pathlib import Path
@@ -673,26 +674,70 @@ class MCPServerAdapter:
         cookie_session_id: Optional[str] = None
 
         # Handle session cookies if present (may also contain the session id)
-        set_cookie_header = connect_response.headers.get("set-cookie")
-        if set_cookie_header:
+        cookie_values: "OrderedDict[str, str]" = OrderedDict()
+
+        # Gather cookies directly from Set-Cookie headers to preserve server ordering.
+        raw_set_cookie_headers: List[str] = []
+        headers_obj = getattr(connect_response, "headers", None)
+        if headers_obj is not None:
+            if hasattr(headers_obj, "get_list"):
+                raw_set_cookie_headers = list(headers_obj.get_list("set-cookie"))
+            else:
+                header_value = headers_obj.get("set-cookie")
+                if header_value:
+                    raw_set_cookie_headers = [header_value]
+
+        for header_value in raw_set_cookie_headers:
             cookie_jar = SimpleCookie()
             try:
-                cookie_jar.load(set_cookie_header)
-                morsels = list(cookie_jar.values())
-                if morsels:
-                    session_cookie_header = "; ".join(
-                        f"{morsel.key}={morsel.value}" for morsel in morsels
-                    )
-                    for morsel in morsels:
-                        if morsel.key and morsel.key.lower() == "sessionid":
-                            cookie_session_id = morsel.value
-                    logger.debug(
-                        f"Using session cookie for {server_name}: {session_cookie_header}"
-                    )
+                cookie_jar.load(header_value)
             except Exception as exc:
                 logger.warning(
                     f"Failed to parse session cookie for server '{server_name}': {exc}"
                 )
+                continue
+
+            for morsel in cookie_jar.values():
+                cookie_name = (morsel.key or "").strip()
+                cookie_value = morsel.value
+                if not cookie_name:
+                    continue
+
+                cookie_values[cookie_name] = cookie_value
+                if cookie_name.lower() == "sessionid" and cookie_value:
+                    cookie_session_id = cookie_value
+
+        # Merge cookies tracked by httpx on the response object to cover cases where
+        # middleware consolidates Set-Cookie headers.
+        try:
+            response_cookies = getattr(connect_response, "cookies", None)
+            cookie_jar_obj = (
+                getattr(response_cookies, "jar", None)
+                if response_cookies is not None
+                else None
+            )
+            if cookie_jar_obj:
+                for cookie in cookie_jar_obj:
+                    cookie_name = getattr(cookie, "name", "").strip()
+                    cookie_value = getattr(cookie, "value", "")
+                    if not cookie_name:
+                        continue
+
+                    cookie_values[cookie_name] = cookie_value
+                    if cookie_name.lower() == "sessionid" and cookie_value:
+                        cookie_session_id = cookie_value
+        except Exception as exc:
+            logger.debug(
+                f"Failed to inspect response cookie jar for server '{server_name}': {exc}"
+            )
+
+        if cookie_values:
+            session_cookie_header = "; ".join(
+                f"{name}={value}" for name, value in cookie_values.items()
+            )
+            logger.debug(
+                f"Using session cookies for {server_name}: {session_cookie_header}"
+            )
 
         # Handle 307 Temporary Redirect
         if connect_response.status_code == 307:
@@ -711,16 +756,33 @@ class MCPServerAdapter:
             query_params = parse_qs(parsed.query)
             normalized_query = {key.lower(): value for key, value in query_params.items()}
             session_id_from_query = normalized_query.get("sessionid", [None])[0]
-            if session_id_from_query:
-                session_id = session_id_from_query
-            elif cookie_session_id is not None:
-                session_id = cookie_session_id
-                logger.debug(
-                    f"Using sessionid from cookie for server '{server_name}' after redirect"
+            if (
+                session_id_from_query
+                and cookie_session_id
+                and session_id_from_query != cookie_session_id
+            ):
+                logger.warning(
+                    "Session ID mismatch between redirect query and cookies for "
+                    f"server '{server_name}'. Preferring the redirect query value."
                 )
+
+            session_id_candidate = session_id_from_query or cookie_session_id
+
+            if session_id_from_query:
+                logger.debug(
+                    f"Using sessionid from redirect query for server '{server_name}'"
+                )
+            elif cookie_session_id:
+                logger.debug(
+                    f"Using sessionid from session cookies for server '{server_name}'"
+                )
+
+            if session_id_candidate:
+                session_id = session_id_candidate
             else:
+                cookie_names = ", ".join(cookie_values.keys()) if cookie_values else "none"
                 logger.error(
-                    f"Missing sessionid in redirect URL for server '{server_name}': {redirect_url}"
+                    f"Missing sessionid for server '{server_name}' after redirect; cookie names: {cookie_names}"
                 )
                 if allow_rest_fallback:
                     logger.warning(
@@ -735,7 +797,7 @@ class MCPServerAdapter:
                     }
                     return
                 raise ValueError(
-                    f"Missing sessionid in redirect URL for server '{server_name}'"
+                    f"Missing sessionid in redirect for server '{server_name}'"
                 )
 
         # Handle 200 OK with JSON endpoint
@@ -755,16 +817,33 @@ class MCPServerAdapter:
                 query_params = parse_qs(parsed.query)
                 normalized_query = {key.lower(): value for key, value in query_params.items()}
                 session_id_from_query = normalized_query.get("sessionid", [None])[0]
-                if session_id_from_query:
-                    session_id = session_id_from_query
-                elif cookie_session_id is not None:
-                    session_id = cookie_session_id
-                    logger.debug(
-                        f"Using sessionid from cookie for server '{server_name}' after JSON endpoint"
+                if (
+                    session_id_from_query
+                    and cookie_session_id
+                    and session_id_from_query != cookie_session_id
+                ):
+                    logger.warning(
+                        "Session ID mismatch between endpoint query and cookies for "
+                        f"server '{server_name}'. Preferring the endpoint value."
                     )
+
+                session_id_candidate = session_id_from_query or cookie_session_id
+
+                if session_id_from_query:
+                    logger.debug(
+                        f"Using sessionid from endpoint query for server '{server_name}'"
+                    )
+                elif cookie_session_id:
+                    logger.debug(
+                        f"Using sessionid from session cookies for server '{server_name}'"
+                    )
+
+                if session_id_candidate:
+                    session_id = session_id_candidate
                 else:
+                    cookie_names = ", ".join(cookie_values.keys()) if cookie_values else "none"
                     logger.error(
-                        f"Missing sessionid in endpoint URL for server '{server_name}': {redirect_url}"
+                        f"Missing sessionid for server '{server_name}' after JSON endpoint; cookie names: {cookie_names}"
                     )
                     if allow_rest_fallback:
                         logger.warning(
@@ -779,7 +858,7 @@ class MCPServerAdapter:
                         }
                         return
                     raise ValueError(
-                        f"Missing sessionid in endpoint URL for server '{server_name}'"
+                        f"Missing sessionid in endpoint for server '{server_name}'"
                     )
 
             except (ValueError, KeyError) as e:

--- a/tests/services/test_mcp_adapter.py
+++ b/tests/services/test_mcp_adapter.py
@@ -3,7 +3,7 @@ import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 import sys
 
 import httpx
@@ -26,25 +26,49 @@ from python_service.app.services.mcp_adapter import MCPServerAdapter  # noqa: E4
 
 
 @pytest.mark.parametrize(
-    "status_code,redirect_suffix,json_payload,set_cookie_header,expected_session_id,expected_cookie_header",
+    "status_code,redirect_suffix,json_payload,set_cookie_headers,response_cookies,expected_session_id,expected_cookie_header",
     [
-        (307, "/sse?sessionid=abc123", None, None, "abc123", None),
-        (307, "/sse?sessionId=abc123", None, None, "abc123", None),
+        (307, "/sse?sessionid=abc123", None, None, None, "abc123", None),
+        (307, "/sse?sessionId=abc123", None, None, None, "abc123", None),
         (
             307,
             "/sse",
             None,
-            "sessionId=abc123; Path=/; HttpOnly",
+            ["sessionId=abc123; Path=/; HttpOnly"],
+            None,
             "abc123",
             "sessionId=abc123",
+        ),
+        (
+            307,
+            "/sse",
+            None,
+            [
+                "sessionId=abc123; Path=/; HttpOnly",
+                "sessionId.sig=xyz789; Path=/; HttpOnly",
+            ],
+            None,
+            "abc123",
+            "sessionId=abc123; sessionId.sig=xyz789",
         ),
         (
             200,
             "/sse",
             {"endpoint": "/sse"},
-            "sessionId=abc123; Path=/; HttpOnly",
+            ["sessionId=abc123; Path=/; HttpOnly"],
+            None,
             "abc123",
             "sessionId=abc123",
+        ),
+        pytest.param(
+            307,
+            "/sse",
+            None,
+            None,
+            {"sessionId": "abc123", "sessionId.sig": "xyz789"},
+            "abc123",
+            "sessionId=abc123; sessionId.sig=xyz789",
+            id="cookies-from-response-jar",
         ),
     ],
 )
@@ -53,13 +77,19 @@ def test_sse_tool_listing_and_execution(
     status_code,
     redirect_suffix,
     json_payload,
-    set_cookie_header,
+    set_cookie_headers,
+    response_cookies,
     expected_session_id,
     expected_cookie_header,
 ):
     """The adapter should establish an SSE session and execute DuckDuckGo tools."""
 
     events: Dict[str, Any] = {}
+
+    def split_cookie_header(value: Optional[str]) -> List[str]:
+        if not value:
+            return []
+        return sorted(part.strip() for part in value.split(";") if part.strip())
 
     @asynccontextmanager
     async def fake_sse_client(
@@ -106,16 +136,30 @@ def test_sse_tool_listing_and_execution(
 
     async def handler(request: Request) -> Response:
         if request.method == "POST" and request.url.path == "/servers/duckduckgo/connect":
-            response_headers = {}
-            if set_cookie_header:
-                response_headers["set-cookie"] = set_cookie_header
+            response_headers = []
+            if set_cookie_headers:
+                response_headers.extend(
+                    ("set-cookie", header_value) for header_value in set_cookie_headers
+                )
             if status_code == 307:
-                response_headers["location"] = redirect_suffix
-                return Response(status_code, headers=response_headers)
-            if status_code == 200:
-                assert json_payload is not None, "JSON payload must be provided for 200 responses"
-                return Response(status_code, headers=response_headers, json=json_payload)
-            raise AssertionError(f"Unsupported status code for test: {status_code}")
+                response_headers.append(("location", redirect_suffix))
+            elif status_code == 200:
+                assert (
+                    json_payload is not None
+                ), "JSON payload must be provided for 200 responses"
+            else:
+                raise AssertionError(f"Unsupported status code for test: {status_code}")
+
+            response_kwargs: Dict[str, Any] = {"headers": response_headers}
+            if status_code == 200 and json_payload is not None:
+                response_kwargs["json"] = json_payload
+
+            response = Response(status_code, request=request, **response_kwargs)
+            if response_cookies:
+                for name, value in response_cookies.items():
+                    response.cookies.set(name, value)
+
+            return response
         if request.method == "POST" and request.url.path == "/servers/duckduckgo/disconnect":
             return Response(200, json={"status": "disconnected"})
         raise AssertionError(f"Unexpected request: {request.method} {request.url}")
@@ -130,14 +174,22 @@ def test_sse_tool_listing_and_execution(
         assert "duckduckgo_web_search" in tools
         connection = adapter._connected_servers["duckduckgo"]
         assert connection["session_id"] == expected_session_id
-        assert connection.get("session_cookie") == expected_cookie_header
+        actual_connection_cookie = connection.get("session_cookie")
+        if expected_cookie_header:
+            assert split_cookie_header(actual_connection_cookie) == split_cookie_header(
+                expected_cookie_header
+            )
+        else:
+            assert actual_connection_cookie in (None, "")
         assert isinstance(connection.get("client"), FakeClientSession)
         expected_sse_url = f"http://mock{redirect_suffix}"
         assert events["sse_url"] == expected_sse_url
         sse_headers = events.get("sse_headers")
         if expected_cookie_header:
             assert sse_headers is not None
-            assert sse_headers.get("Cookie") == expected_cookie_header
+            assert split_cookie_header(sse_headers.get("Cookie")) == split_cookie_header(
+                expected_cookie_header
+            )
         else:
             assert not sse_headers or "Cookie" not in sse_headers
         assert events.get("listed_tools")


### PR DESCRIPTION
## Summary
- collect SSE cookies from both raw Set-Cookie headers and the httpx response jar so the outbound stream reuses every cookie pair and captures the canonical session id
- update the SSE session id resolution logic to favor redirect query strings but gracefully fall back to cookie values while logging useful diagnostics
- broaden the SSE adapter tests to cover cookie-jar-only responses and normalize cookie header assertions

## Testing
- pytest tests/services/test_mcp_adapter.py -q
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68d0a890f2f08330bb8a6ccbaee805b9