### PR TITLE
Handle session ID from cookies for SSE connections

### DIFF
--- a/python-service/app/services/mcp_adapter.py
+++ b/python-service/app/services/mcp_adapter.py
@@ -676,6 +676,10 @@ class MCPServerAdapter:
         # Handle session cookies if present (may also contain the session id)
         cookie_values: "OrderedDict[str, str]" = OrderedDict()
 
+        def _is_session_cookie(name: str) -> bool:
+            normalized = name.lower().replace("_", "").replace("-", "")
+            return normalized == "sessionid"
+
         # Gather cookies directly from Set-Cookie headers to preserve server ordering.
         raw_set_cookie_headers: List[str] = []
         headers_obj = getattr(connect_response, "headers", None)
@@ -704,7 +708,7 @@ class MCPServerAdapter:
                     continue
 
                 cookie_values[cookie_name] = cookie_value
-                if cookie_name.lower() == "sessionid" and cookie_value:
+                if _is_session_cookie(cookie_name) and cookie_value:
                     cookie_session_id = cookie_value
 
         # Merge cookies tracked by httpx on the response object to cover cases where
@@ -724,7 +728,7 @@ class MCPServerAdapter:
                         continue
 
                     cookie_values[cookie_name] = cookie_value
-                    if cookie_name.lower() == "sessionid" and cookie_value:
+                    if _is_session_cookie(cookie_name) and cookie_value:
                         cookie_session_id = cookie_value
         except Exception as exc:
             logger.debug(

--- a/tests/services/test_mcp_adapter.py
+++ b/tests/services/test_mcp_adapter.py
@@ -43,6 +43,15 @@ from python_service.app.services.mcp_adapter import MCPServerAdapter  # noqa: E4
             307,
             "/sse",
             None,
+            ["session_id=abc123; Path=/; HttpOnly"],
+            None,
+            "abc123",
+            "session_id=abc123",
+        ),
+        (
+            307,
+            "/sse",
+            None,
             [
                 "sessionId=abc123; Path=/; HttpOnly",
                 "sessionId.sig=xyz789; Path=/; HttpOnly",


### PR DESCRIPTION
## Summary
- treat Set-Cookie values as a source of SSE session identifiers when redirects omit the query parameter
- continue forwarding the parsed cookie header to the SSE client and save it with the connected server entry
- cover 307 redirects that only provide the session id via Set-Cookie in the adapter test suite

## Testing
- python -m py_compile $(git ls-files '*.py')
- pytest tests/services/test_mcp_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68d0cca9f73483309f453497978b65ee