### PR TITLE
Normalize session ID parsing for MCP SSE connections

### DIFF
--- a/python-service/app/services/mcp_adapter.py
+++ b/python-service/app/services/mcp_adapter.py
@@ -676,9 +676,13 @@ class MCPServerAdapter:
         # Handle session cookies if present (may also contain the session id)
         cookie_values: "OrderedDict[str, str]" = OrderedDict()
 
+        def _normalize_session_key(name: Optional[str]) -> str:
+            if not name:
+                return ""
+            return name.strip().lower().replace("_", "").replace("-", "")
+
         def _is_session_cookie(name: str) -> bool:
-            normalized = name.lower().replace("_", "").replace("-", "")
-            return normalized == "sessionid"
+            return _normalize_session_key(name) == "sessionid"
 
         # Gather cookies directly from Set-Cookie headers to preserve server ordering.
         raw_set_cookie_headers: List[str] = []
@@ -758,7 +762,9 @@ class MCPServerAdapter:
             # Extract sessionid from redirect URL
             parsed = urlparse(redirect_url)
             query_params = parse_qs(parsed.query)
-            normalized_query = {key.lower(): value for key, value in query_params.items()}
+            normalized_query = {
+                _normalize_session_key(key): value for key, value in query_params.items()
+            }
             session_id_from_query = normalized_query.get("sessionid", [None])[0]
             if (
                 session_id_from_query
@@ -819,7 +825,10 @@ class MCPServerAdapter:
                 # Extract sessionid from endpoint URL
                 parsed = urlparse(redirect_url)
                 query_params = parse_qs(parsed.query)
-                normalized_query = {key.lower(): value for key, value in query_params.items()}
+                normalized_query = {
+                    _normalize_session_key(key): value
+                    for key, value in query_params.items()
+                }
                 session_id_from_query = normalized_query.get("sessionid", [None])[0]
                 if (
                     session_id_from_query

--- a/tests/services/test_mcp_adapter.py
+++ b/tests/services/test_mcp_adapter.py
@@ -30,6 +30,7 @@ from python_service.app.services.mcp_adapter import MCPServerAdapter  # noqa: E4
     [
         (307, "/sse?sessionid=abc123", None, None, None, "abc123", None),
         (307, "/sse?sessionId=abc123", None, None, None, "abc123", None),
+        (307, "/sse?session_id=abc123", None, None, None, "abc123", None),
         (
             307,
             "/sse",


### PR DESCRIPTION
## Summary
- normalize session identifiers from SSE redirect and JSON endpoint URLs using a shared key normalizer
- continue reusing the helper for cookie detection to support common session id variants
- add a parametrized test covering the `session_id` redirect query variant for the MCP adapter

## Testing
- pytest tests/services/test_mcp_adapter.py
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68d0d0cbf544833089d851bfc6ed8338