### PR TITLE
Align MCP adapter timeout configuration

### DIFF
--- a/python-service/app/services/mcp_adapter.py
+++ b/python-service/app/services/mcp_adapter.py
@@ -169,7 +169,12 @@ class MCPServerAdapter:
                 sse_response = await self._session.get(
                     self._sse_endpoint,
                     headers={"Accept": "text/event-stream"},
-                    timeout=httpx.Timeout(connect=self.config.connection_timeout)
+                    timeout=httpx.Timeout(
+                        connect=self.config.connection_timeout,
+                        read=self.config.discovery_timeout,
+                        write=self.config.execution_timeout,
+                        pool=self.config.connection_timeout
+                    )
                 )
                 sse_response.raise_for_status()
                 
@@ -211,7 +216,12 @@ class MCPServerAdapter:
             # Try to get tools from gateway endpoint
             tools_response = await self._session.get(
                 f"{self.config.gateway_url}/servers/{server_name}/tools",
-                timeout=httpx.Timeout(read=self.config.discovery_timeout)
+                timeout=httpx.Timeout(
+                    connect=self.config.connection_timeout,
+                    read=self.config.discovery_timeout,
+                    write=self.config.execution_timeout,
+                    pool=self.config.connection_timeout
+                )
             )
             
             if tools_response.status_code == 404:
@@ -326,7 +336,12 @@ class MCPServerAdapter:
                     "session_id": self._session_id,
                     "arguments": arguments,
                 },
-                timeout=httpx.Timeout(read=self.config.execution_timeout)
+                timeout=httpx.Timeout(
+                    connect=self.config.connection_timeout,
+                    read=self.config.execution_timeout,
+                    write=self.config.execution_timeout,
+                    pool=self.config.connection_timeout
+                )
             )
             response.raise_for_status()
             


### PR DESCRIPTION
## Summary
- set explicit connect/read/write/pool timeout values when initializing the SSE transport
- align tool discovery and execution requests with the adapter's configured timeout values

## Testing
- python -m py_compile $(git ls-files '*.py')
- python - <<'PY' ... (mock MCP gateway exercise)


------
https://chatgpt.com/codex/tasks/task_e_68d189a29cd883309c40e1d7c4f509af