### PR TITLE
feat: wire MCP tooling into LinkedIn job search crew

### DIFF
--- a/docs/linkedin_job_search_crews.md
+++ b/docs/linkedin_job_search_crews.md
@@ -17,9 +17,18 @@ Both crews integrate with the existing `jobs` database table and follow establis
 Execute LinkedIn job searches with explicit user-defined inputs and retrieve personalized recommendations.
 
 ### Architecture
-- **search_agent**: Calls LinkedIn API `search_jobs` with provided parameters
-- **recommendation_agent**: Calls LinkedIn API `get_recommended_jobs` for authenticated users
-- **orchestration_agent**: Consolidates and deduplicates results from both agents
+- **linkedin_job_searcher**: Executes targeted job discovery via the MCP `linkedin_search` tool
+- **job_opportunity_analyzer**: Evaluates opportunities, blending MCP `linkedin_search` results with `profile_lookup` insights
+- **networking_strategist**: Crafts outreach plans using MCP-driven `profile_lookup` contact research
+- **linkedin_report_writer**: Consolidates findings from the MCP-enabled specialists
+
+### MCP Gateway Integration
+The crew connects to the MCP gateway using configuration loaded at runtime. Tool wrappers are cached for reuse so that
+specialists can repeatedly call LinkedIn-focused tools without reinitializing the gateway.
+
+- `linkedin_job_searcher` leverages the `linkedin_search` tool for live job retrieval.
+- `job_opportunity_analyzer` cross-checks postings and companies with `linkedin_search` and `profile_lookup`.
+- `networking_strategist` uses `profile_lookup` to surface decision makers and warm introductions.
 
 ### API Endpoint
 ```http

--- a/python-service/app/services/crewai/linkedin_job_search/config/agents.yaml
+++ b/python-service/app/services/crewai/linkedin_job_search/config/agents.yaml
@@ -6,8 +6,9 @@ linkedin_job_searcher:
     A specialized recruiter who excels at using LinkedIn's advanced search features
     to find targeted job opportunities. You understand how to craft effective search
     queries, filter results by company size, location, experience level, and industry.
-    You have access to web research tools to gather the latest job postings and
-    company information from LinkedIn.
+    You work through the MCP gateway and regularly invoke the `linkedin_search`
+    tool to retrieve the latest LinkedIn postings, ensuring recommendations reflect
+    real-time hiring activity and verified job details.
   llm: "openai/gpt-5-mini"
   temperature: 0.3
   memory: false
@@ -23,8 +24,9 @@ job_opportunity_analyzer:
     on LinkedIn for their alignment with candidate profiles. You assess job
     requirements, company culture indicators, growth potential, and market
     competitiveness. You focus on providing actionable insights about whether
-    a LinkedIn job posting is worth pursuing.
-    You have access to web research tools to gather additional context about companies and roles.
+    a LinkedIn job posting is worth pursuing. You combine outputs from the
+    `linkedin_search` tool with on-demand context gathered through the MCP
+    `profile_lookup` tool to validate company and role insights before scoring them.
   llm: "openai/gpt-5-mini"
   temperature: 0.2
   memory: false
@@ -39,8 +41,9 @@ networking_strategist:
     A professional networking expert who specializes in LinkedIn relationship building
     and strategic outreach. You identify key contacts at target companies, recommend
     connection strategies, and suggest personalized messaging approaches. You understand
-    how to leverage LinkedIn's network effects for job search success.
-    You have access to web research tools to research company employees and networking opportunities.
+    how to leverage LinkedIn's network effects for job search success. Using the MCP
+    `profile_lookup` tool you surface decision makers, alumni connections, and warm
+    introduction paths to craft outreach strategies backed by current LinkedIn data.
   llm: "openai/gpt-5-mini"
   temperature: 0.4
   memory: false
@@ -57,7 +60,7 @@ linkedin_report_writer:
     results, opportunity analyses, and networking strategies into cohesive reports
     that help job seekers make informed decisions about their LinkedIn job search
     approach. You prioritize clarity and actionability in your recommendations.
-    As the manager agent, you coordinate the work of specialist agents and ensure
+    As the manager agent, you coordinate MCP-enabled specialists and ensure
     comprehensive coverage of all LinkedIn job search aspects.
   llm: "openai/gpt-5-mini"
   temperature: 0.3


### PR DESCRIPTION
## Summary
- initialize a shared MCP gateway and tool cache for the LinkedIn job search crew so agents receive cached MCPToolWrapper instances
- update LinkedIn job search agent copy and documentation to call out the required MCP tools and runtime wiring
- expand the LinkedIn job search crew tests to mock the MCP factory, cover success and failure flows, and ensure singleton state resets between runs

## Testing
- python -m py_compile $(git ls-files '*.py')
- pytest python-service/tests/services/test_linkedin_job_search_crew.py


------
https://chatgpt.com/codex/tasks/task_e_68d22a4e9e68833083597d510fe50793