### PR TITLE
Fix LinkedIn recommended jobs crew exports

### DIFF
--- a/python-service/app/services/crewai/AGENTS.md
+++ b/python-service/app/services/crewai/AGENTS.md
@@ -36,6 +36,13 @@ The Python service includes four active CrewAI multi-agent services:
 - **Agents**: LinkedIn Job Searcher, Job Opportunity Analyzer, Networking Strategist, LinkedIn Report Writer
 - **Usage**: Searches LinkedIn for opportunities, analyzes fit, and develops networking strategies
 
+### 5. LinkedIn Recommended Jobs (`linkedin_recommended_jobs`)
+- **Purpose**: Retrieves personalized LinkedIn job recommendations and normalizes them for downstream services
+- **Location**: `app/services/crewai/linkedin_recommended_jobs/`
+- **Agents**: Job Collector, Job Details Specialist, Documentation Steward
+- **Usage**: Fetches recommended LinkedIn jobs via MCP, enriches details, and normalizes to the JobPosting schema
+
+
 All CrewAI services follow YAML-first configuration and modular agent design patterns.
 
 ## File Structure Overview
@@ -68,12 +75,18 @@ app/services/crewai/
 │   └── config/
 │       ├── agents.yaml              # Company research agents
 │       └── tasks.yaml               # Company research tasks
-└── linkedin_job_search/             # LinkedIn job search crew
+├── linkedin_job_search/             # LinkedIn job search crew
+│   ├── __init__.py
+│   ├── crew.py                      # LinkedInJobSearchCrew class
+│   └── config/
+│       ├── agents.yaml              # LinkedIn job search agents
+│       └── tasks.yaml               # LinkedIn job search tasks
+└── linkedin_recommended_jobs/       # LinkedIn recommended jobs crew
     ├── __init__.py
-    ├── crew.py                      # LinkedInJobSearchCrew class
+    ├── crew.py                      # LinkedInRecommendedJobsCrew class
     └── config/
-        ├── agents.yaml              # LinkedIn job search agents
-        └── tasks.yaml               # LinkedIn job search tasks
+        ├── agents.yaml              # LinkedIn recommended jobs agents
+        └── tasks.yaml               # LinkedIn recommended jobs tasks
 ```
 
 ### Required Files for Each Crew

--- a/python-service/app/services/crewai/linkedin_recommended_jobs/__init__.py
+++ b/python-service/app/services/crewai/linkedin_recommended_jobs/__init__.py
@@ -1,19 +1,24 @@
 """LinkedIn Recommended Jobs CrewAI implementation.
 
-This crew is responsible for fetching job postings from LinkedIn and normalizing 
-them into the JobPosting schema. It does not perform any recommendation logic, 
+This crew is responsible for fetching job postings from LinkedIn and normalizing
+them into the JobPosting schema. It does not perform any recommendation logic,
 filtering, ranking, or evaluation of job fit.
 
 Key Functions:
 - Fetch personalized job recommendations using MCP LinkedIn tools
-- Retrieve detailed job posting information  
+- Retrieve detailed job posting information
 - Normalize output to JobPosting schema
 - Update project documentation
 """
 
-from .crew import LinkedInRecommendedJobsCrew, get_linkedin_recommended_jobs_crew
+from .crew import (
+    LinkedInRecommendedJobsCrew,
+    get_linkedin_recommended_jobs_crew,
+    run_linkedin_recommended_jobs,
+)
 
 __all__ = [
     "LinkedInRecommendedJobsCrew",
     "get_linkedin_recommended_jobs_crew",
+    "run_linkedin_recommended_jobs",
 ]


### PR DESCRIPTION
## Summary
- export `run_linkedin_recommended_jobs` from the LinkedIn recommended jobs crew package so the FastAPI service can import it
- document the LinkedIn recommended jobs crew in the CrewAI architecture guide and update the crew directory tree

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68d2f2e980a8833088aebe6c65bd7213