### PR TITLE
Fix document viewer to use existing Chroma endpoints

### DIFF
--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -8,7 +8,7 @@ import {
     BragBankEntry, BragBankEntryPayload, SkillTrend, SkillTrendPayload,
     Sprint, SprintAction, CreateSprintPayload, SprintActionPayload, ApplicationQuestion,
     SiteSchedule, SiteDetails, SiteSchedulePayload,
-    UploadedDocument, UploadSuccessResponse
+    UploadedDocument, UploadSuccessResponse, ContentType
 } from '../types';
 import { API_BASE_URL, USER_ID, FASTAPI_BASE_URL } from '../constants';
 import { v4 as uuidv4 } from 'uuid';
@@ -1330,15 +1330,82 @@ export const uploadResume = async (formData: FormData): Promise<UploadSuccessRes
 };
 
 // Fetching documents for the viewer
-export const getUploadedDocuments = async (profileId: string): Promise<UploadedDocument[]> => {
-    if (!profileId) return [];
-    const response = await fetch(`${FASTAPI_BASE_URL}/documents?profile_id=${profileId}`);
-    const data = await handleResponse(response);
-    return data.documents || [];
+const COLLECTIONS_BY_CONTENT_TYPE: Record<ContentType, string> = {
+    career_brand: 'career_brand',
+    career_path: 'career_paths',
+    job_search_strategy: 'job_search_strategies',
+    resume: 'resumes',
 };
 
-export const deleteUploadedDocument = async (documentId: string): Promise<void> => {
-    const response = await fetch(`${FASTAPI_BASE_URL}/documents/${documentId}`, {
+const inferProfileFromTags = (tags: string | undefined, fallback: string): string => {
+    if (!tags) return fallback;
+    const segments = tags.split(',').map(segment => segment.trim()).filter(Boolean);
+    // Tags follow the pattern: [content_type, profile_id, section]
+    if (segments.length >= 2) {
+        return segments[1];
+    }
+    return fallback;
+};
+
+const inferSectionFromMetadata = (metadata: Record<string, any> | undefined, tags: string | undefined): string => {
+    if (metadata?.section) {
+        return metadata.section;
+    }
+
+    if (tags) {
+        const segments = tags.split(',').map(segment => segment.trim()).filter(Boolean);
+        if (segments.length >= 3) {
+            return segments[2];
+        }
+    }
+
+    return 'General';
+};
+
+export const getUploadedDocuments = async (profileId: string): Promise<UploadedDocument[]> => {
+    if (!profileId) return [];
+
+    const collectionEntries = Object.entries(COLLECTIONS_BY_CONTENT_TYPE) as [ContentType, string][];
+
+    const documentGroups = await Promise.all(
+        collectionEntries.map(async ([contentType, collectionName]) => {
+            const response = await fetch(`${FASTAPI_BASE_URL}/chroma/collections/${collectionName}/documents`);
+            const data = await handleResponse(response);
+            const documents = (data?.documents || []) as Array<Record<string, any>>;
+
+            return documents
+                .filter(doc => {
+                    const metadata = doc.metadata as Record<string, any> | undefined;
+                    const derivedProfileId = metadata?.profile_id || inferProfileFromTags(doc.tags, '');
+                    return derivedProfileId === profileId;
+                })
+                .map(doc => {
+                    const metadata = (doc.metadata || {}) as Record<string, any>;
+                    const section = inferSectionFromMetadata(metadata, doc.tags);
+                    const createdAt = metadata.uploaded_at || doc.created_at || new Date().toISOString();
+
+                    return {
+                        id: doc.id,
+                        profile_id: metadata.profile_id || inferProfileFromTags(doc.tags, profileId),
+                        title: doc.title || metadata.title || 'Untitled',
+                        section,
+                        content_type: contentType,
+                        created_at: createdAt,
+                    } as UploadedDocument;
+                });
+        })
+    );
+
+    return documentGroups.flat().sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+};
+
+export const deleteUploadedDocument = async (documentId: string, contentType: ContentType): Promise<void> => {
+    const collectionName = COLLECTIONS_BY_CONTENT_TYPE[contentType];
+    if (!collectionName) {
+        throw new Error(`Unknown content type '${contentType}'`);
+    }
+
+    const response = await fetch(`${FASTAPI_BASE_URL}/chroma/collections/${collectionName}/documents/${documentId}`, {
         method: 'DELETE',
     });
     await handleResponse(response);


### PR DESCRIPTION
## Summary
- update the document viewer to toast failures and delete documents via their content type aware routes
- switch document queries to existing Chroma collection endpoints and map their metadata into the UploadedDocument shape
- expose chunk metadata from the Chroma service so the frontend can filter by profile and section

## Testing
- npm run build
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68d5b3df82108330ba76d4a969931a78