### PR TITLE
Ensure scheduler cleans up locks on malformed payloads

### DIFF
--- a/python-service/app/services/infrastructure/scheduler.py
+++ b/python-service/app/services/infrastructure/scheduler.py
@@ -5,7 +5,7 @@ import uuid
 import random
 import json
 from datetime import datetime, timezone, timedelta
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional
 from loguru import logger
 
 from .database import get_database_service
@@ -14,7 +14,7 @@ from .queue import get_queue_service
 
 class SchedulerService:
     """Service for scheduling periodic job scraping tasks."""
-    
+
     def __init__(self):
         self.db_service = get_database_service()
         self.queue_service = get_queue_service()
@@ -25,14 +25,14 @@ class SchedulerService:
         try:
             db_init = await self.db_service.initialize()
             queue_init = await self.queue_service.initialize()
-            
+
             self.initialized = db_init and queue_init
-            
+
             if self.initialized:
                 logger.info("Scheduler service initialized successfully")
             else:
                 logger.error("Failed to initialize scheduler dependencies")
-                
+
             return self.initialized
         except Exception as e:
             logger.error(f"Failed to initialize scheduler: {str(e)}")
@@ -41,48 +41,55 @@ class SchedulerService:
     async def process_scheduled_sites(self) -> int:
         """
         Process all enabled site schedules that are due for execution.
-        
+
         Returns:
             Number of jobs enqueued
         """
         if not self.initialized:
             logger.warning("Scheduler not initialized")
             return 0
-        
+
         try:
             # Get all enabled sites that are due
             schedules = await self.db_service.get_enabled_site_schedules()
             jobs_enqueued = 0
-            
+
             logger.info(f"Found {len(schedules)} site schedules to process")
-            
+
             for schedule in schedules:
+                lock_key: Optional[str] = None
+                lock_value: Optional[str] = None
+                run_id: Optional[str] = None
+                lock_acquired = False
+
                 try:
                     site_name = schedule["site_name"]
                     schedule_id = str(schedule["id"])
-                    
+
                     # Check for existing running jobs for this site (per-site lock)
                     lock_key = f"scrape_lock:{site_name}"
                     existing_lock = self.queue_service.check_redis_lock(lock_key)
-                    
+
                     if existing_lock:
                         logger.info(f"Site {site_name} is already being scraped, skipping")
                         continue
-                    
+
                     # Check database for running jobs as backup
                     if await self.db_service.check_site_lock(site_name):
                         logger.info(f"Site {site_name} has running jobs in database, skipping")
                         continue
-                    
+
                     # Generate unique run ID
                     run_id = f"sched_{uuid.uuid4().hex[:8]}"
-                    
+
                     # Acquire Redis lock for this site
                     lock_value = f"{run_id}:{datetime.now(timezone.utc).isoformat()}"
                     if not self.queue_service.acquire_redis_lock(lock_key, lock_value, timeout=1800):  # 30 min timeout
                         logger.warning(f"Failed to acquire lock for site {site_name}")
                         continue
-                    
+
+                    lock_acquired = True
+
                     # Create scrape run record
                     scrape_run_id = await self.db_service.create_scrape_run(
                         run_id=run_id,
@@ -90,12 +97,11 @@ class SchedulerService:
                         task_id="",  # Will be updated after enqueueing
                         trigger="schedule"
                     )
-                    
+
                     if not scrape_run_id:
                         logger.error(f"Failed to create scrape run record for {site_name}")
-                        self.queue_service.release_redis_lock(lock_key, lock_value)
                         continue
-                    
+
                     # Enqueue the job with site name included in payload
                     payload_dict = schedule["payload"]
                     if isinstance(payload_dict, str):
@@ -103,15 +109,35 @@ class SchedulerService:
                             payload_dict = json.loads(payload_dict)
                         except json.JSONDecodeError as json_err:
                             logger.error(f"Failed to parse payload JSON for {site_name}: {json_err}")
+                            if run_id:
+                                await self.db_service.update_scrape_run_status(
+                                    run_id=run_id,
+                                    status="failed",
+                                    message=f"Failed to parse payload JSON: {json_err}"
+                                )
+                            if lock_acquired and lock_key and lock_value:
+                                self.queue_service.release_redis_lock(lock_key, lock_value)
+                                lock_acquired = False
+                                lock_value = None
                             continue
-                    
+
                     # Ensure payload_dict is a dictionary
                     if not isinstance(payload_dict, dict):
                         logger.error(f"Payload is not a dictionary for {site_name}: {type(payload_dict)}")
+                        if run_id:
+                            await self.db_service.update_scrape_run_status(
+                                run_id=run_id,
+                                status="failed",
+                                message=f"Payload must be a dictionary, got {type(payload_dict).__name__}"
+                            )
+                        if lock_acquired and lock_key and lock_value:
+                            self.queue_service.release_redis_lock(lock_key, lock_value)
+                            lock_acquired = False
+                            lock_value = None
                         continue
 
                     payload = {**payload_dict, "site_name": schedule["site_name"]}
-                    
+
                     # Choose the appropriate queue method based on site type
                     if site_name.lower() == "linkedin":
                         # Use LinkedIn job search for LinkedIn sites
@@ -129,7 +155,7 @@ class SchedulerService:
                             trigger="schedule",
                             run_id=run_id
                         )
-                    
+
                     if job_info:
                         task_id = job_info["task_id"]
 
@@ -140,38 +166,46 @@ class SchedulerService:
                             task_id=task_id,
                             message=f"Scheduled scrape for {site_name}"
                         )
-                        
+
                         # Calculate next run time with jitter
                         interval_minutes = schedule["interval_minutes"]
                         jitter_percent = random.uniform(-0.1, 0.1)  # ±10% jitter
                         jittered_minutes = interval_minutes * (1 + jitter_percent)
                         next_run_at = datetime.now(timezone.utc) + timedelta(minutes=jittered_minutes)
-                        
+
                         # Update schedule next run time
                         await self.db_service.update_site_schedule_next_run(schedule_id, next_run_at)
-                        
+
                         logger.info(
                             f"Enqueued scheduled job for {site_name} - "
                             f"run_id: {run_id}, task_id: {task_id}, "
                             f"next_run: {next_run_at.isoformat()}"
                         )
-                        
+
                         jobs_enqueued += 1
-                        
+
                         # Release the lock - the worker will manage its own execution
                         # The lock was just to prevent duplicate scheduling
-                        self.queue_service.release_redis_lock(lock_key, lock_value)
+                        if lock_acquired and lock_key and lock_value:
+                            self.queue_service.release_redis_lock(lock_key, lock_value)
+                            lock_acquired = False
+                            lock_value = None
                     else:
                         logger.error(f"Failed to enqueue job for {site_name}")
-                        self.queue_service.release_redis_lock(lock_key, lock_value)
-                        
+
                         # Update scrape run to failed
-                        await self.db_service.update_scrape_run_status(
-                            run_id=run_id,
-                            status="failed",
-                            message="Failed to enqueue job"
-                        )
-                        
+                        if run_id:
+                            await self.db_service.update_scrape_run_status(
+                                run_id=run_id,
+                                status="failed",
+                                message="Failed to enqueue job"
+                            )
+
+                        if lock_acquired and lock_key and lock_value:
+                            self.queue_service.release_redis_lock(lock_key, lock_value)
+                            lock_acquired = False
+                            lock_value = None
+
                 except Exception as e:
                     site_name = "unknown"
                     try:
@@ -179,16 +213,39 @@ class SchedulerService:
                             site_name = schedule.get('site_name', 'unknown')
                         else:
                             site_name = f"invalid_schedule_type_{type(schedule).__name__}"
-                    except:
+                    except Exception:
                         pass  # Keep default site_name if we can't extract it
+
                     logger.error(f"Error processing schedule for {site_name}: {str(e)}")
+
+                    if run_id:
+                        try:
+                            await self.db_service.update_scrape_run_status(
+                                run_id=run_id,
+                                status="failed",
+                                message=f"Scheduler error for {site_name}: {str(e)}"
+                            )
+                        except Exception as update_err:
+                            logger.error(f"Failed to mark scrape run {run_id} as failed: {update_err}")
+
+                    if lock_acquired and lock_key and lock_value:
+                        self.queue_service.release_redis_lock(lock_key, lock_value)
+                        lock_acquired = False
+                        lock_value = None
+
                     continue
-            
+
+                finally:
+                    if lock_acquired and lock_key and lock_value:
+                        self.queue_service.release_redis_lock(lock_key, lock_value)
+                        lock_acquired = False
+                        lock_value = None
+
             if jobs_enqueued > 0:
                 logger.info(f"Scheduler enqueued {jobs_enqueued} jobs")
-            
+
             return jobs_enqueued
-            
+
         except Exception as e:
             logger.error(f"Error in process_scheduled_sites: {str(e)}")
             return 0
@@ -198,20 +255,20 @@ class SchedulerService:
         try:
             if not self.initialized:
                 return {"status": "not_initialized", "error": "Scheduler not initialized"}
-            
+
             # Get queue info
             queue_info = self.queue_service.get_queue_info()
-            
+
             # Get enabled schedules count
             schedules = await self.db_service.get_enabled_site_schedules()
-            
+
             return {
                 "status": "running",
                 "enabled_sites": len(schedules),
                 "queue_info": queue_info,
                 "last_check": datetime.now(timezone.utc).isoformat()
             }
-            
+
         except Exception as e:
             logger.error(f"Error getting scheduler status: {str(e)}")
             return {"status": "error", "error": str(e)}

--- a/python-service/tests/services/test_scheduler_service.py
+++ b/python-service/tests/services/test_scheduler_service.py
@@ -1,0 +1,63 @@
+import asyncio
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+from app.services.infrastructure.scheduler import SchedulerService
+
+
+def test_malformed_payload_marks_run_failed_and_releases_lock():
+    async def run_test():
+        mock_db_service = Mock()
+        mock_db_service.initialize = AsyncMock(return_value=True)
+        mock_db_service.get_enabled_site_schedules = AsyncMock(return_value=[{
+            "site_name": "ExampleSite",
+            "id": "schedule-1",
+            "payload": "{not-json",
+            "interval_minutes": 30,
+        }])
+        mock_db_service.check_site_lock = AsyncMock(return_value=False)
+        mock_db_service.create_scrape_run = AsyncMock(return_value="scrape-run-db-id")
+        mock_db_service.update_scrape_run_status = AsyncMock(return_value=True)
+        mock_db_service.update_site_schedule_next_run = AsyncMock(return_value=True)
+
+        mock_queue_service = Mock()
+        mock_queue_service.initialize = AsyncMock(return_value=True)
+        mock_queue_service.get_queue_info = Mock(return_value={})
+        mock_queue_service.check_redis_lock = Mock(return_value=False)
+        mock_queue_service.acquire_redis_lock = Mock(return_value=True)
+        mock_queue_service.release_redis_lock = Mock()
+        mock_queue_service.enqueue_scraping_job = Mock()
+        mock_queue_service.enqueue_linkedin_job_search = Mock()
+
+        fake_uuid = Mock(hex="cafebabe12345678")
+
+        with patch("app.services.infrastructure.scheduler.get_database_service", return_value=mock_db_service), \
+             patch("app.services.infrastructure.scheduler.get_queue_service", return_value=mock_queue_service), \
+             patch("app.services.infrastructure.scheduler.uuid.uuid4", return_value=fake_uuid):
+
+            scheduler = SchedulerService()
+            scheduler.initialized = True
+
+            jobs_enqueued = await scheduler.process_scheduled_sites()
+
+        assert jobs_enqueued == 0
+
+        mock_queue_service.acquire_redis_lock.assert_called_once()
+        mock_queue_service.release_redis_lock.assert_called_once()
+        lock_args = mock_queue_service.release_redis_lock.call_args[0]
+        assert lock_args[0] == "scrape_lock:ExampleSite"
+        assert lock_args[1].startswith("sched_cafebabe")
+
+        mock_db_service.create_scrape_run.assert_awaited_once()
+        mock_db_service.update_scrape_run_status.assert_awaited_once()
+        status_call = mock_db_service.update_scrape_run_status.await_args_list[0]
+        assert status_call.kwargs["run_id"].startswith("sched_cafebabe")
+        assert status_call.kwargs["status"] == "failed"
+        assert "Failed to parse payload JSON" in status_call.kwargs["message"]
+
+        mock_queue_service.enqueue_scraping_job.assert_not_called()
+        mock_queue_service.enqueue_linkedin_job_search.assert_not_called()
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- ensure scheduler tracks acquired locks and run identifiers for each schedule iteration
- mark runs as failed and release Redis locks when payload parsing or validation errors occur, and mirror the cleanup for unexpected exceptions
- add regression coverage verifying malformed payloads trigger lock release and failed run status updates

## Testing
- python -m py_compile $(git ls-files '*.py')
- pytest python-service/tests/services/test_scheduler_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d5cc323354833099a6b6bc1e8804eb