### PR TITLE
Add task task run polling for resume tailoring and company research

### DIFF
--- a/python-service/app/api/router.py
+++ b/python-service/app/api/router.py
@@ -20,6 +20,7 @@ from .v1.endpoints.applications import router as applications_router
 from .v1.endpoints.glassdoor_enrichment import router as glassdoor_enrichment_router
 
 from ..routes.jobs_fit_review import router as jobs_fit_review_router
+from ..routes.task_runs import router as task_runs_router
 
 api_router = APIRouter(prefix="/api")
 
@@ -48,5 +49,6 @@ api_router.include_router(glassdoor_enrichment_router, tags=["Glassdoor Enrichme
 # Health check
 api_router.include_router(health_router, tags=["Health"])
 api_router.include_router(jobs_fit_review_router, tags=["job-posting-fit-review"])
+api_router.include_router(task_runs_router, tags=["AI Tasks"])
 
 __all__ = ["api_router"]

--- a/python-service/app/routes/task_runs.py
+++ b/python-service/app/routes/task_runs.py
@@ -1,0 +1,190 @@
+"""Routes for AI task queue management."""
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..dependencies import get_queue_service, get_database_service
+from ..services.infrastructure.queue import QueueService
+from ..services.infrastructure.database import DatabaseService
+
+
+class ResumeTailoringRequest(BaseModel):
+    application_id: str = Field(..., description="Application identifier")
+    job_description: str = Field(..., description="Full job description text")
+    resume_json: Dict[str, Any] = Field(..., description="Base resume JSON payload")
+    resume_summary: str = Field("", description="Resume summary paragraph")
+    company_context: Dict[str, Any] = Field(default_factory=dict)
+    narrative: Dict[str, Any] = Field(default_factory=dict)
+    job_analysis: Optional[Dict[str, Any]] = Field(default=None)
+
+
+class CompanyResearchRequest(BaseModel):
+    company_id: Optional[str] = Field(None, description="Company identifier if available")
+    company_name: str = Field(..., description="Company name to research")
+    homepage_url: Optional[str] = Field(None, description="Company homepage URL")
+
+
+class TaskEnqueueResponse(BaseModel):
+    run_id: str
+    task_id: str
+    status: str = Field("queued")
+
+
+class TaskRunStatusResponse(BaseModel):
+    run_id: str
+    task_type: str
+    status: str
+    trigger: str
+    reference_id: Optional[str]
+    schedule_id: Optional[str]
+    task_id: Optional[str]
+    started_at: Optional[str]
+    finished_at: Optional[str]
+    created_at: Optional[str]
+    updated_at: Optional[str]
+    result: Optional[Any]
+    error: Optional[str]
+
+
+router = APIRouter(prefix="/tasks", tags=["AI Tasks"])
+
+
+@router.post("/resume-tailoring", response_model=TaskEnqueueResponse)
+async def enqueue_resume_tailoring(
+    request: ResumeTailoringRequest,
+    queue_service: QueueService = Depends(get_queue_service),
+    db_service: DatabaseService = Depends(get_database_service),
+) -> TaskEnqueueResponse:
+    if not queue_service.initialized:
+        await queue_service.initialize()
+    if not db_service.initialized:
+        await db_service.initialize()
+
+    run_id = f"resume_{uuid4().hex[:8]}"
+
+    await db_service.create_ai_task_run(
+        run_id=run_id,
+        task_type="resume_tailoring",
+        trigger="manual",
+        reference_id=request.application_id,
+        payload=request.model_dump(),
+    )
+
+    job_info = queue_service.enqueue_resume_tailoring_job(
+        application_id=request.application_id,
+        payload=request.model_dump(),
+        run_id=run_id,
+        trigger="manual",
+    )
+
+    if not job_info:
+        await db_service.update_ai_task_run(
+            run_id,
+            status="failed",
+            error="Failed to enqueue resume tailoring job",
+        )
+        raise HTTPException(status_code=500, detail="Failed to enqueue resume tailoring job")
+
+    await db_service.update_ai_task_run(
+        run_id,
+        status="queued",
+        task_id=job_info["task_id"],
+    )
+
+    return TaskEnqueueResponse(run_id=run_id, task_id=job_info["task_id"])
+
+
+@router.post("/company-research", response_model=TaskEnqueueResponse)
+async def enqueue_company_research(
+    request: CompanyResearchRequest,
+    queue_service: QueueService = Depends(get_queue_service),
+    db_service: DatabaseService = Depends(get_database_service),
+) -> TaskEnqueueResponse:
+    if not queue_service.initialized:
+        await queue_service.initialize()
+    if not db_service.initialized:
+        await db_service.initialize()
+
+    run_id = f"company_{uuid4().hex[:8]}"
+
+    payload = {
+        "company_id": request.company_id,
+        "company_name": request.company_name,
+        "homepage_url": request.homepage_url,
+    }
+
+    await db_service.create_ai_task_run(
+        run_id=run_id,
+        task_type="company_research",
+        trigger="manual",
+        reference_id=request.company_id,
+        payload=payload,
+    )
+
+    job_info = queue_service.enqueue_company_research_job(
+        company_id=request.company_id,
+        payload=payload,
+        run_id=run_id,
+        trigger="manual",
+    )
+
+    if not job_info:
+        await db_service.update_ai_task_run(
+            run_id,
+            status="failed",
+            error="Failed to enqueue company research job",
+        )
+        raise HTTPException(status_code=500, detail="Failed to enqueue company research job")
+
+    await db_service.update_ai_task_run(
+        run_id,
+        status="queued",
+        task_id=job_info["task_id"],
+    )
+
+    return TaskEnqueueResponse(run_id=run_id, task_id=job_info["task_id"])
+
+
+@router.get("/{run_id}", response_model=TaskRunStatusResponse)
+async def get_task_run_status(
+    run_id: str,
+    queue_service: QueueService = Depends(get_queue_service),
+    db_service: DatabaseService = Depends(get_database_service),
+) -> TaskRunStatusResponse:
+    if not db_service.initialized:
+        await db_service.initialize()
+
+    record = await db_service.get_ai_task_run(run_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="Task run not found")
+
+    task_id = record.get("task_id") or run_id
+    queue_status: Optional[Dict[str, Any]] = None
+
+    if not queue_service.initialized:
+        await queue_service.initialize()
+
+    if task_id:
+        queue_status = queue_service.get_job_status(task_id)
+
+    result = record.get("result")
+    if not result and queue_status and queue_status.get("result"):
+        result = queue_status.get("result")
+
+    return TaskRunStatusResponse(
+        run_id=record["run_id"],
+        task_type=record.get("task_type", "unknown"),
+        status=record.get("status", "unknown"),
+        trigger=record.get("trigger", "manual"),
+        reference_id=record.get("reference_id"),
+        schedule_id=record.get("schedule_id"),
+        task_id=record.get("task_id"),
+        started_at=(record.get("started_at").isoformat() if record.get("started_at") else None),
+        finished_at=(record.get("finished_at").isoformat() if record.get("finished_at") else None),
+        created_at=(record.get("created_at").isoformat() if record.get("created_at") else None),
+        updated_at=(record.get("updated_at").isoformat() if record.get("updated_at") else None),
+        result=result,
+        error=record.get("error"),
+    )

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -9,7 +9,8 @@ import {
     Sprint, SprintAction, CreateSprintPayload, SprintActionPayload, ApplicationQuestion,
     SiteSchedule, SiteDetails, SiteSchedulePayload,
     UploadedDocument, UploadSuccessResponse, ContentType,
-    PaginatedResponse, ReviewedJob, ReviewedJobRecommendation
+    PaginatedResponse, ReviewedJob, ReviewedJobRecommendation,
+    TaskEnqueueResponse, TaskRunRecord, ResumeTailoringJobPayload, CompanyResearchJobPayload
 } from '../types';
 import { API_BASE_URL, USER_ID, FASTAPI_BASE_URL } from '../constants';
 import { v4 as uuidv4 } from 'uuid';
@@ -1515,6 +1516,39 @@ export const fetchLinkedInJobByUrl = async (url: string): Promise<any> => {
 
 export const getJobReviewStatus = async (jobId: string): Promise<any> => {
     const response = await fetch(buildFastApiUrl(`linkedin-jobs/review-status/${jobId}`), {
+        method: 'GET',
+        headers,
+    });
+
+    return handleResponse(response);
+};
+
+export const enqueueResumeTailoringJob = async (
+    payload: ResumeTailoringJobPayload
+): Promise<TaskEnqueueResponse> => {
+    const response = await fetch(buildFastApiUrl('tasks/resume-tailoring'), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+    });
+
+    return handleResponse(response);
+};
+
+export const enqueueCompanyResearchJob = async (
+    payload: CompanyResearchJobPayload
+): Promise<TaskEnqueueResponse> => {
+    const response = await fetch(buildFastApiUrl('tasks/company-research'), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+    });
+
+    return handleResponse(response);
+};
+
+export const getTaskRunStatus = async (runId: string): Promise<TaskRunRecord> => {
+    const response = await fetch(buildFastApiUrl(`tasks/${runId}`), {
         method: 'GET',
         headers,
     });

--- a/types.ts
+++ b/types.ts
@@ -876,6 +876,47 @@ export interface SiteSchedule {
 export type SiteSchedulePayload = Partial<Omit<SiteSchedule, 'id' | 'created_at' | 'updated_at'>>;
 
 
+export type AiTaskType = 'resume_tailoring' | 'company_research' | string;
+
+export interface TaskRunRecord {
+    run_id: string;
+    task_type: AiTaskType;
+    status: 'queued' | 'running' | 'succeeded' | 'failed' | string;
+    trigger: string;
+    reference_id?: string | null;
+    schedule_id?: string | null;
+    task_id?: string | null;
+    started_at?: string | null;
+    finished_at?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    result?: any;
+    error?: string | null;
+}
+
+export interface TaskEnqueueResponse {
+    run_id: string;
+    task_id: string;
+    status: string;
+}
+
+export interface ResumeTailoringJobPayload {
+    application_id: string;
+    job_description: string;
+    resume_json: Record<string, any>;
+    resume_summary: string;
+    company_context?: Record<string, any>;
+    narrative?: Record<string, any>;
+    job_analysis?: Record<string, any> | null;
+}
+
+export interface CompanyResearchJobPayload {
+    company_id?: string;
+    company_name: string;
+    homepage_url?: string;
+}
+
+
 export const ResumeTemplate: Resume = {
   header: { first_name: "", last_name: "", job_title: "", email: "", phone_number: "", city: "", state: "", links: [] },
   summary: { paragraph: "", bullets: [] },


### PR DESCRIPTION
## Summary
- add AI task run persistence and FastAPI routes for enqueueing and polling resume tailoring and company research jobs
- extend queue, worker, and scheduler infrastructure to process the new job types
- wire React Query polling into the new application flow and company detail views with user-visible status updates

## Testing
- python -m py_compile $(git ls-files '*.py')
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2f78ca9dc8330b9d2b9ddddcfec57