### PR TITLE
Add resume-driven Chroma collections and HITL hooks

### DIFF
--- a/hooks/apiHooks.ts
+++ b/hooks/apiHooks.ts
@@ -1,6 +1,9 @@
+import { useEffect, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import * as apiService from '../services/apiService';
 import { Company, BaseResume, Resume, SiteSchedule, SiteDetails, SiteSchedulePayload } from '../types';
+import { ReviewedJobsFilters, ReviewedJobsSort, JobReviewOverrideRequest } from '../services/apiService';
 
 export const useGetCompanies = () => {
   return useQuery<Company[], Error>({
@@ -68,6 +71,53 @@ export const useDeleteSiteSchedule = () => {
   return useMutation({
     mutationFn: (scheduleId: string) => apiService.deleteSiteSchedule(scheduleId),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['siteSchedules'] }),
+  });
+};
+
+type ReviewedJobsQueryArgs = {
+  page?: number;
+  size?: number;
+  filters?: ReviewedJobsFilters;
+  sort?: ReviewedJobsSort;
+};
+
+export const useReviewedJobs = ({ page = 1, size = 15, filters = {}, sort = { by: 'date_posted', order: 'desc' } }: ReviewedJobsQueryArgs) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const apiSearchString = useMemo(
+    () => apiService.buildReviewedJobsSearchParams({ page, size, filters, sort }).toString(),
+    [page, size, filters, sort]
+  );
+
+  const uiSearchString = useMemo(
+    () => apiService.buildReviewedJobsUiSearchParams({ page, size, filters, sort }).toString(),
+    [page, size, filters, sort]
+  );
+
+  useEffect(() => {
+    const nextSearch = uiSearchString ? `?${uiSearchString}` : '';
+    if (location.search !== nextSearch) {
+      navigate(`${location.pathname}${nextSearch}`, { replace: true });
+    }
+  }, [uiSearchString, location.pathname, location.search, navigate]);
+
+  return useQuery({
+    queryKey: ['reviewedJobs', apiSearchString],
+    queryFn: () => apiService.getReviewedJobs({ page, size, filters, sort }),
+    keepPreviousData: true,
+  });
+};
+
+export const useOverrideJobReview = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ jobId, payload }: { jobId: string; payload: JobReviewOverrideRequest }) =>
+      apiService.overrideJobReview(jobId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['reviewedJobs'] });
+    },
   });
 };
 

--- a/python-service/app/services/chroma_manager.py
+++ b/python-service/app/services/chroma_manager.py
@@ -24,6 +24,9 @@ class CollectionType(Enum):
     GENERIC_DOCUMENTS = "documents"
     CAREER_RESEARCH = "career_research"
     JOB_SEARCH_RESEARCH = "job_search_research"
+    RESUME_ACHIEVEMENTS = "resume_achievements"
+    USER_EXPERTISE = "user_expertise"
+    COMPANY_VOICE_PATTERNS = "company_voice_patterns"
 
 
 class ChromaCollectionConfig:
@@ -111,6 +114,68 @@ class ChromaManager:
                 "timestamp": "str",            # ISO timestamp
                 "narrative_id": "str",         # Which narrative owns this
                 "uploaded_at": "str"           # Upload timestamp
+            }
+        ))
+
+        # Resume achievement bullets tuned for ATS-optimized chunk sizes
+        self.register_collection_config(ChromaCollectionConfig(
+            name="resume_achievements",
+            collection_type=CollectionType.RESUME_ACHIEVEMENTS,
+            description="Individual resume achievement bullets with role and impact metadata",
+            chunk_size=120,
+            chunk_overlap=20,
+            metadata_schema={
+                "profile_id": "str",
+                "resume_id": "str",
+                "achievement_id": "str",
+                "work_experience_id": "str",
+                "job_title": "str",
+                "company_name": "str",
+                "date_range": "str",
+                "themes": "list",
+                "always_include": "bool",
+                "order_index": "int",
+                "impact_scope": "str",
+                "updated_at": "str"
+            }
+        ))
+
+        # Aggregated skill and summary expertise slices for personalization
+        self.register_collection_config(ChromaCollectionConfig(
+            name="user_expertise",
+            collection_type=CollectionType.USER_EXPERTISE,
+            description="Summaries of user expertise areas, skills, and narrative highlights",
+            chunk_size=180,
+            chunk_overlap=30,
+            metadata_schema={
+                "profile_id": "str",
+                "resume_id": "str",
+                "expertise_area": "str",
+                "seniority": "str",
+                "skills": "list",
+                "years_experience": "str",
+                "source": "str",
+                "updated_at": "str"
+            }
+        ))
+
+        # Company voice and tone exemplars extracted from resume experience
+        self.register_collection_config(ChromaCollectionConfig(
+            name="company_voice_patterns",
+            collection_type=CollectionType.COMPANY_VOICE_PATTERNS,
+            description="Voice and tone exemplars derived from resume experience with specific companies",
+            chunk_size=220,
+            chunk_overlap=35,
+            metadata_schema={
+                "profile_id": "str",
+                "resume_id": "str",
+                "company_name": "str",
+                "job_title": "str",
+                "industry": "str",
+                "tone_hint": "str",
+                "keywords": "list",
+                "accomplishment_count": "int",
+                "updated_at": "str"
             }
         ))
 

--- a/python-service/scripts/migrate_resumes_to_chroma.py
+++ b/python-service/scripts/migrate_resumes_to_chroma.py
@@ -1,0 +1,367 @@
+"""Populate Chroma collections with resume-derived context."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+from loguru import logger
+
+# Ensure the python-service package is importable when running as a script
+CURRENT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = CURRENT_DIR.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from app.core.config import get_settings  # noqa: E402
+from app.services.chroma_integration_service import ChromaIntegrationService  # noqa: E402
+
+USER_ID = os.getenv("USER_ID", "11111111-2222-3333-4444-555555555555")
+RESUME_SELECT_QUERY = (
+    "resume_id,resume_name,is_locked,summary_paragraph,summary_bullets,"
+    "resume_work_experience(*,resume_accomplishments(*)),"
+    "resume_education(*),"
+    "resume_certifications(*),"
+    "resume_skill_sections(*,resume_skill_items(*))"
+)
+
+
+@dataclass
+class ResumeRecord:
+    """Container for resume base metadata and hydrated content."""
+
+    base: Dict[str, Any]
+    content: Dict[str, Any]
+
+
+async def fetch_json(client: httpx.AsyncClient, url: str) -> Any:
+    """Fetch JSON content with logging and error handling."""
+    try:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.json()
+    except Exception as exc:  # pragma: no cover - network issues
+        logger.error(f"Request failed for {url}: {exc}")
+        raise
+
+
+async def fetch_user_profile(client: httpx.AsyncClient, base_url: str) -> Dict[str, Any]:
+    """Fetch minimal user profile data required for resume context."""
+    fields = "first_name,last_name,email,phone_number,city,state,links"
+    url = f"{base_url}/users?user_id=eq.{USER_ID}&select={fields}"
+    data = await fetch_json(client, url)
+    if data:
+        return data[0]
+    return {}
+
+
+async def fetch_resumes(client: httpx.AsyncClient, base_url: str) -> List[ResumeRecord]:
+    """Fetch resumes and hydrate them with nested content."""
+    list_url = f"{base_url}/resumes?user_id=eq.{USER_ID}&order=resume_name.asc"
+    resume_list = await fetch_json(client, list_url)
+
+    records: List[ResumeRecord] = []
+    for base_resume in resume_list or []:
+        resume_id = base_resume.get("resume_id")
+        if not resume_id:
+            continue
+
+        detail_url = (
+            f"{base_url}/resumes?resume_id=eq.{resume_id}&user_id=eq.{USER_ID}&select={RESUME_SELECT_QUERY}"
+        )
+        detail_data = await fetch_json(client, detail_url)
+        content = detail_data[0] if detail_data else {}
+        records.append(ResumeRecord(base=base_resume, content=content))
+
+    return records
+
+
+def format_date(date_info: Optional[Dict[str, Any]]) -> str:
+    """Render a human-friendly month/year string."""
+    if not date_info:
+        return ""
+    year = date_info.get("year")
+    month = date_info.get("month")
+    if not year:
+        return ""
+    if month:
+        try:
+            return datetime(year, month, 1).strftime("%b %Y")
+        except ValueError:  # pragma: no cover - defensive
+            return str(year)
+    return str(year)
+
+
+def format_date_range(experience: Dict[str, Any]) -> str:
+    """Build a date range label for work experience."""
+    start = format_date(experience.get("start_date"))
+    end_info = experience.get("end_date")
+    is_current = experience.get("is_current")
+    end = "Present" if is_current else format_date(end_info)
+    if start and end:
+        return f"{start} – {end}"
+    return start or end or ""
+
+
+def flatten_keywords(values: Optional[List[Any]]) -> List[str]:
+    """Ensure keyword values are consistently strings."""
+    if not values:
+        return []
+    keywords: List[str] = []
+    for item in values:
+        if isinstance(item, str):
+            keywords.append(item)
+        elif isinstance(item, dict):
+            keywords.extend(str(v) for v in item.values())
+        else:
+            keywords.append(str(item))
+    return [keyword for keyword in {k.strip(): k.strip() for k in keywords if k}.values() if keyword]
+
+
+def summarise_accomplishment(accomplishment: Dict[str, Any], experience: Dict[str, Any]) -> str:
+    """Compose a descriptive text block for an accomplishment."""
+    lines: List[str] = []
+    description = accomplishment.get("description") or accomplishment.get("original_description")
+    if description:
+        lines.append(description)
+
+    ai_suggestion = accomplishment.get("ai_suggestion")
+    if ai_suggestion:
+        lines.append(f"AI Suggestion: {ai_suggestion}")
+
+    keyword_suggestions = flatten_keywords(accomplishment.get("keyword_suggestions"))
+    if keyword_suggestions:
+        lines.append(f"Keyword Suggestions: {', '.join(keyword_suggestions)}")
+
+    themes = flatten_keywords(accomplishment.get("themes"))
+    if themes:
+        lines.append(f"Themes: {', '.join(themes)}")
+
+    score = accomplishment.get("score") or accomplishment.get("original_score")
+    if isinstance(score, dict) and score:
+        score_parts = ", ".join(f"{k}: {v}" for k, v in score.items())
+        lines.append(f"Score: {score_parts}")
+
+    role_context = f"Role: {experience.get('job_title', '')} at {experience.get('company_name', '')}".strip()
+    if role_context:
+        lines.append(role_context)
+
+    return "\n".join(lines).strip()
+
+
+def build_resume_document(content: Dict[str, Any], user_profile: Dict[str, Any]) -> str:
+    """Create a holistic resume document string for vector storage."""
+    lines: List[str] = []
+
+    first_name = user_profile.get("first_name")
+    last_name = user_profile.get("last_name")
+    if first_name or last_name:
+        lines.append(f"{first_name or ''} {last_name or ''}".strip())
+
+    contact_bits = [
+        user_profile.get("email"),
+        user_profile.get("phone_number"),
+        ", ".join(filter(None, [user_profile.get("city"), user_profile.get("state")])) or None,
+    ]
+    contact_line = " | ".join(filter(None, contact_bits))
+    if contact_line:
+        lines.append(contact_line)
+
+    links = user_profile.get("links") or []
+    if links:
+        lines.append("Links: " + ", ".join(str(link) for link in links if link))
+
+    summary_paragraph = content.get("summary_paragraph")
+    if summary_paragraph:
+        lines.append("Summary: " + summary_paragraph)
+
+    summary_bullets = content.get("summary_bullets") or []
+    for bullet in summary_bullets:
+        lines.append(f"• {bullet}")
+
+    for experience in content.get("resume_work_experience") or []:
+        title = experience.get("job_title") or ""
+        company = experience.get("company_name") or ""
+        location = experience.get("location") or ""
+        date_range = format_date_range(experience)
+        header_parts = [part for part in [title, company, location, date_range] if part]
+        if header_parts:
+            lines.append(" | ".join(header_parts))
+
+        for accomplishment in experience.get("resume_accomplishments") or []:
+            accomplishment_text = summarise_accomplishment(accomplishment, experience)
+            if accomplishment_text:
+                lines.append(f"- {accomplishment_text}")
+
+    for section in content.get("resume_skill_sections") or []:
+        section_name = section.get("section_name") or "Skills"
+        items = section.get("resume_skill_items") or []
+        skill_names = [item.get("skill_name") for item in items if item.get("skill_name")]
+        if skill_names:
+            lines.append(f"{section_name}: {', '.join(skill_names)}")
+
+    for education in content.get("resume_education") or []:
+        school = education.get("school") or ""
+        degree = education.get("degree") or ""
+        majors = education.get("major") or []
+        education_line = " | ".join(filter(None, [school, degree, ", ".join(majors)]))
+        if education_line:
+            lines.append(education_line)
+
+    for cert in content.get("resume_certifications") or []:
+        name = cert.get("name")
+        if name:
+            authority = cert.get("authority")
+            issued = cert.get("issue_date")
+            lines.append("Certification: " + ", ".join(filter(None, [name, authority, issued])))
+
+    return "\n".join(lines).strip()
+
+
+async def migrate() -> None:
+    """Main migration routine."""
+    settings = get_settings()
+    base_url = settings.postgrest_url.rstrip("/")
+
+    logger.info("Fetching resume data from PostgREST at {url}", url=base_url)
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        user_profile = await fetch_user_profile(client, base_url)
+        resumes = await fetch_resumes(client, base_url)
+
+    if not resumes:
+        logger.warning("No resumes found for migration")
+        return
+
+    service = ChromaIntegrationService()
+    await service.initialize()
+
+    resume_uploads = 0
+    achievement_uploads = 0
+    expertise_uploads = 0
+    voice_uploads = 0
+
+    for record in resumes:
+        resume_id = record.base.get("resume_id")
+        resume_name = record.base.get("resume_name", "Resume")
+        updated_at = record.base.get("updated_at")
+
+        resume_text = build_resume_document(record.content, user_profile)
+        metadata = {
+            "resume_id": resume_id,
+            "uploaded_from": "migration_script",
+        }
+        if updated_at:
+            metadata["updated_at"] = updated_at
+
+        if resume_text:
+            await service.add_resume_document(
+                title=resume_name,
+                content=resume_text,
+                profile_id=USER_ID,
+                section="resume",
+                additional_metadata=metadata,
+            )
+            resume_uploads += 1
+
+        for experience in record.content.get("resume_work_experience") or []:
+            experience_id = experience.get("resume_work_experience_id") or experience.get("id")
+            company_name = experience.get("company_name") or ""
+            job_title = experience.get("job_title") or ""
+            date_range = format_date_range(experience)
+            industry = experience.get("industry") or ""
+
+            accomplishment_texts: List[str] = []
+            accumulated_keywords: List[str] = []
+
+            for accomplishment in experience.get("resume_accomplishments") or []:
+                achievement_id = accomplishment.get("achievement_id") or accomplishment.get("id") or os.urandom(4).hex()
+                themes = flatten_keywords(accomplishment.get("themes"))
+                accomplishment_text = summarise_accomplishment(accomplishment, experience)
+                if not accomplishment_text:
+                    continue
+
+                accomplishment_texts.append(accomplishment_text)
+                accumulated_keywords.extend(flatten_keywords(accomplishment.get("keyword_suggestions")))
+
+                await service.add_resume_achievement(
+                    profile_id=USER_ID,
+                    resume_id=resume_id,
+                    achievement_id=achievement_id,
+                    content=accomplishment_text,
+                    job_title=job_title,
+                    company_name=company_name,
+                    work_experience_id=experience_id,
+                    date_range=date_range,
+                    always_include=bool(accomplishment.get("always_include")),
+                    order_index=accomplishment.get("order_index"),
+                    themes=themes,
+                    impact_scope="team" if "team" in (t.lower() for t in themes) else "organization" if themes else "",
+                )
+                achievement_uploads += 1
+
+            if accomplishment_texts:
+                tone_hint = "metrics-forward" if any(char.isdigit() for text in accomplishment_texts for char in text) else "narrative"
+                await service.add_company_voice_pattern(
+                    profile_id=USER_ID,
+                    resume_id=resume_id,
+                    company_name=company_name,
+                    job_title=job_title,
+                    content="\n".join(accomplishment_texts),
+                    industry=industry,
+                    tone_hint=tone_hint,
+                    keywords=list({kw for kw in accumulated_keywords if kw}),
+                    accomplishment_count=len(accomplishment_texts),
+                )
+                voice_uploads += 1
+
+        summary_paragraph = record.content.get("summary_paragraph") or ""
+        summary_bullets = record.content.get("summary_bullets") or []
+        summary_text_parts = [summary_paragraph] + summary_bullets
+        summary_text = "\n".join(part for part in summary_text_parts if part)
+        if summary_text:
+            await service.add_user_expertise_document(
+                profile_id=USER_ID,
+                resume_id=resume_id,
+                expertise_area="Executive Summary",
+                content=summary_text,
+                skills=[],
+                seniority="Executive" if "executive" in summary_text.lower() else "",  # heuristic
+                source="summary",
+            )
+            expertise_uploads += 1
+
+        for section in record.content.get("resume_skill_sections") or []:
+            section_name = section.get("section_name") or "Skills"
+            skills = [item.get("skill_name") for item in section.get("resume_skill_items") or [] if item.get("skill_name")]
+            if not skills:
+                continue
+
+            section_text = f"{section_name}: {', '.join(skills)}"
+            await service.add_user_expertise_document(
+                profile_id=USER_ID,
+                resume_id=resume_id,
+                expertise_area=section_name,
+                content=section_text,
+                skills=skills,
+                source="skills",
+            )
+            expertise_uploads += 1
+
+    logger.success(
+        "Resume migration complete | resumes=%d achievements=%d expertise=%d voice_patterns=%d",
+        resume_uploads,
+        achievement_uploads,
+        expertise_uploads,
+        voice_uploads,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(migrate())

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -1356,12 +1356,116 @@ export const deleteUploadedDocument = async (documentId: string, contentType: Co
 export interface ReviewedJobsFilters {
   recommendation?: 'All' | 'Recommended' | 'Not Recommended';
   min_score?: number;
+  max_score?: number;
+  company?: string;
+  source?: string;
+  is_remote?: boolean | null;
+  date_posted_after?: string;
+  date_posted_before?: string;
 }
 
 export interface ReviewedJobsSort {
   by: 'date_posted' | 'overall_alignment_score' | 'review_date';
   order: 'asc' | 'desc';
 }
+
+export const buildReviewedJobsSearchParams = ({ page = 1, size = 15, filters = {}, sort = { by: 'date_posted', order: 'desc' } }: {
+    page?: number;
+    size?: number;
+    filters?: ReviewedJobsFilters;
+    sort?: ReviewedJobsSort;
+}): URLSearchParams => {
+    const params = new URLSearchParams({
+        limit: String(size),
+        offset: String(Math.max(page - 1, 0) * size),
+    });
+
+    const sortByParam = sort.by;
+    params.append('sort_by', sortByParam);
+    params.append('sort_order', sort.order.toUpperCase());
+
+    if (filters.recommendation && filters.recommendation !== 'All') {
+        params.append('recommendation', filters.recommendation === 'Recommended' ? 'true' : 'false');
+    }
+
+    if (typeof filters.min_score === 'number') {
+        params.append('min_score', String(filters.min_score));
+    }
+
+    if (typeof filters.max_score === 'number') {
+        params.append('max_score', String(filters.max_score));
+    }
+
+    if (filters.company) {
+        params.append('company', filters.company);
+    }
+
+    if (filters.source) {
+        params.append('source', filters.source);
+    }
+
+    if (typeof filters.is_remote === 'boolean') {
+        params.append('is_remote', String(filters.is_remote));
+    }
+
+    if (filters.date_posted_after) {
+        params.append('date_posted_after', filters.date_posted_after);
+    }
+
+    if (filters.date_posted_before) {
+        params.append('date_posted_before', filters.date_posted_before);
+    }
+
+    return params;
+};
+
+export const buildReviewedJobsUiSearchParams = ({ page = 1, size = 15, filters = {}, sort = { by: 'date_posted', order: 'desc' } }: {
+    page?: number;
+    size?: number;
+    filters?: ReviewedJobsFilters;
+    sort?: ReviewedJobsSort;
+}): URLSearchParams => {
+    const params = new URLSearchParams();
+
+    params.set('page', String(page));
+    params.set('size', String(size));
+    params.set('sort_by', sort.by);
+    params.set('sort_order', sort.order);
+
+    if (filters.recommendation && filters.recommendation !== 'All') {
+        params.set('recommendation', filters.recommendation);
+    }
+
+    if (typeof filters.min_score === 'number') {
+        params.set('min_score', String(filters.min_score));
+    }
+
+    if (typeof filters.max_score === 'number') {
+        params.set('max_score', String(filters.max_score));
+    }
+
+    if (filters.company) {
+        params.set('company', filters.company);
+    }
+
+    if (filters.source) {
+        params.set('source', filters.source);
+    }
+
+    if (typeof filters.is_remote === 'boolean') {
+        params.set('is_remote', String(filters.is_remote));
+    }
+
+    if (filters.date_posted_after) {
+        params.set('date_posted_after', filters.date_posted_after);
+    }
+
+    if (filters.date_posted_before) {
+        params.set('date_posted_before', filters.date_posted_before);
+    }
+
+    return params;
+};
 
 export const getReviewedJobs = async ({ page = 1, size = 15, filters = {}, sort = { by: 'date_posted', order: 'desc' } }: {
     page?: number;
@@ -1385,23 +1489,7 @@ export const getReviewedJobs = async ({ page = 1, size = 15, filters = {}, sort 
         return String(value);
     };
 
-    const params = new URLSearchParams({
-        limit: String(size),
-        offset: String(Math.max(page - 1, 0) * size),
-    });
-
-    const sortByParam = sort.by;
-    params.append('sort_by', sortByParam);
-    params.append('sort_order', sort.order.toUpperCase());
-
-    if (filters.recommendation && filters.recommendation !== 'All') {
-        params.append('recommendation', filters.recommendation === 'Recommended' ? 'true' : 'false');
-    }
-
-    if (typeof filters.min_score === 'number') {
-        params.append('min_score', String(filters.min_score));
-    }
-
+    const params = buildReviewedJobsSearchParams({ page, size, filters, sort });
     const response = await fetch(`${buildFastApiUrl('jobs/reviews')}?${params.toString()}`);
     const rawData = await handleResponse(response);
 


### PR DESCRIPTION
## Summary
- register resume achievements, user expertise, and company voice pattern collections with tailored chunking and metadata plus upload/query helpers in the integration service
- add an async migration script that hydrates resumes from PostgREST and pushes achievements, expertise slices, and voice patterns into Chroma
- extend the reviewed jobs API surface with query param builders and React Query hooks to sync HITL filters into the URL and support overrides

## Testing
- python -m py_compile $(git ls-files '*.py')
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3364905448330806dd9fd3295ccb2