### PR TITLE
Ensure single application fetch returns prep workspace fields

### DIFF
--- a/components/ApplicationDetailView.tsx
+++ b/components/ApplicationDetailView.tsx
@@ -418,7 +418,7 @@ export const ApplicationDetailView = (props: ApplicationDetailViewProps) => {
                                              <button onClick={() => onOpenStrategyStudio(interview)} disabled={isLoading} className="p-1.5 text-xs font-semibold rounded-md bg-white dark:bg-slate-700 ring-1 ring-inset ring-slate-300 dark:ring-slate-600 inline-flex items-center gap-1.5 hover:bg-slate-50" title="Open Strategy Studio">
                                                 <StrategyIcon className="h-4 w-4"/> Studio
                                              </button>
-                                             <button onClick={() => { setEditingInterviewId(interview.interview_id); setEditableInterview({ interview_type: interview.interview_type, interview_date: interview.interview_date, notes: interview.notes, contact_ids: (interview.interview_contacts || []).map(c => c.contact_id) }); }} className="p-1.5 text-xs font-semibold rounded-md bg-white dark:bg-slate-700 ring-1 ring-inset ring-slate-300 dark:ring-slate-600">Edit</button>
+                                            <button onClick={() => { setEditingInterviewId(interview.interview_id); setEditableInterview({ interview_type: interview.interview_type, interview_date: interview.interview_date, live_notes: interview.live_notes || '', contact_ids: (interview.interview_contacts || []).map(c => c.contact_id) }); }} className="p-1.5 text-xs font-semibold rounded-md bg-white dark:bg-slate-700 ring-1 ring-inset ring-slate-300 dark:ring-slate-600">Edit</button>
                                              <button onClick={() => onDeleteInterview(interview.interview_id)} className="p-1 text-red-500 hover:text-red-400" title="Delete Interview"><TrashIcon className="h-5 w-5"/></button>
                                         </div>
                                     </div>
@@ -463,7 +463,7 @@ export const ApplicationDetailView = (props: ApplicationDetailViewProps) => {
                                                 )}
                                             </div>
                                         </div>
-                                        <div><label className={labelClass}>Notes</label><textarea rows={4} value={editableInterview.notes || ''} onChange={e => setEditableInterview(prev => ({...prev, notes: e.target.value}))} className={inputClass} /></div>
+                                        <div><label className={labelClass}>Live Notes</label><textarea rows={4} value={editableInterview.live_notes || ''} onChange={e => setEditableInterview(prev => ({...prev, live_notes: e.target.value}))} className={inputClass} /></div>
                                         <div className="flex justify-end gap-2"><button onClick={() => { setEditingInterviewId(null); setEditableInterview({}); }} className="px-3 py-1.5 text-sm font-semibold rounded-md bg-white dark:bg-slate-700 ring-1 ring-inset ring-slate-300 dark:ring-slate-600 hover:bg-slate-50 dark:hover:bg-slate-600">Cancel</button><button onClick={() => handleSaveInterview({ job_application_id: application.job_application_id, ...editableInterview }, editingInterviewId === 'new' ? undefined : editingInterviewId)} disabled={isSaving} className="px-3 py-1.5 text-sm font-semibold rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50">{isSaving ? <LoadingSpinner/> : 'Save'}</button></div>
                                     </div>
                                 </div>

--- a/components/PostInterviewDebriefStudio.tsx
+++ b/components/PostInterviewDebriefStudio.tsx
@@ -27,10 +27,10 @@ export const PostInterviewDebriefStudio = (props: PostInterviewDebriefStudioProp
     useEffect(() => {
         // Pre-fill the "new_intelligence" field from the copilot notes for this interview.
         // The user can then organize these thoughts into wins/fumbles.
-        if (interview.notes) {
+        if (interview.live_notes) {
             setNotes(prev => ({
                 ...prev,
-                new_intelligence: interview.notes || ''
+                new_intelligence: interview.live_notes || ''
             }));
         }
     }, [interview]);
@@ -54,8 +54,8 @@ export const PostInterviewDebriefStudio = (props: PostInterviewDebriefStudioProp
                 summary += `  - Wins: ${debrief.performance_analysis.wins.join(', ')}\n`;
                 summary += `  - Fumbles: ${debrief.performance_analysis.areas_for_improvement.join(', ')}\n`;
             }
-            if (i.notes) {
-                summary += `  - Raw Notes/Intelligence: ${i.notes.substring(0, 150)}...\n`;
+            if (i.live_notes) {
+                summary += `  - Raw Notes/Intelligence: ${i.live_notes.substring(0, 150)}...\n`;
             }
             return summary;
         }).join('\n');

--- a/components/__tests__/InterviewCopilotView.test.tsx
+++ b/components/__tests__/InterviewCopilotView.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { InterviewCopilotView } from '../InterviewCopilotView';
+import { Company, Interview, JobApplication, JobProblemAnalysisResult, StrategicNarrative } from '../../types';
+
+const jobAnalysis: JobProblemAnalysisResult = {
+    core_problem_analysis: {
+        business_context: 'Retention is lagging in the first 90 days.',
+        core_problem: 'Reducing churn for new customers',
+        strategic_importance: 'Critical for recurring revenue stability'
+    },
+    key_success_metrics: ['Increase day-30 retention to 60%'],
+    role_levers: ['Onboarding experience', 'Lifecycle messaging'],
+    potential_blockers: ['Limited analytics visibility'],
+    suggested_positioning: 'Product leader who has rebuilt onboarding funnels',
+    tags: ['growth', 'activation']
+};
+
+const baseApplication: JobApplication = {
+    job_application_id: 'app-1',
+    user_id: 'user-1',
+    narrative_id: 'nar-1',
+    company_id: 'comp-1',
+    job_title: 'Product Manager',
+    job_description: 'Drive adoption',
+    date_applied: '2024-01-01',
+    created_at: '2024-01-01',
+    job_problem_analysis_result: jobAnalysis
+} as JobApplication;
+
+const baseInterview: Interview = {
+    interview_id: 'int-1',
+    job_application_id: 'app-1',
+    interview_type: 'Hiring Manager',
+    interview_date: '2024-01-10',
+    strategic_opening: 'Opening line',
+    strategic_questions_to_ask: ['How is retention trending?'],
+    story_deck: [],
+    live_notes: 'Initial notes',
+    prep_outline: {
+        role_intelligence: {
+            core_problem: 'Reducing churn for new customers',
+            key_success_metrics: ['Increase day-30 retention to 60%'],
+            role_levers: ['Onboarding experience'],
+            potential_blockers: ['Limited analytics visibility'],
+            suggested_positioning: 'Product leader who has rebuilt onboarding funnels'
+        },
+        jd_insights: {
+            business_context: 'Retention is lagging in the first 90 days.',
+            strategic_importance: 'Critical for recurring revenue stability',
+            tags: ['growth', 'activation']
+        }
+    }
+} as unknown as Interview;
+
+const activeNarrative: StrategicNarrative = {
+    narrative_id: 'nar-1',
+    user_id: 'user-1',
+    narrative_name: 'North Star',
+    desired_title: 'Product Leader',
+    positioning_statement: 'Product operator delivering retention turnarounds',
+    impact_story_title: 'Improved activation by 25%',
+    impact_stories: []
+} as unknown as StrategicNarrative;
+
+const company: Company = {
+    company_id: 'comp-1',
+    user_id: 'user-1',
+    company_name: 'Acme Corp'
+};
+
+describe('InterviewCopilotView', () => {
+    const renderView = () =>
+        render(
+            <InterviewCopilotView
+                application={baseApplication}
+                interview={baseInterview}
+                company={company}
+                activeNarrative={activeNarrative}
+                onBack={() => undefined}
+                onSaveInterview={async () => undefined}
+                onGenerateInterviewPrep={async () => undefined}
+                onGenerateRecruiterScreenPrep={async () => undefined}
+            />
+        );
+
+    it('shows live rundown elements in view mode by default', () => {
+        renderView();
+
+        expect(screen.getByText('Job Cheat Sheet')).toBeInTheDocument();
+        expect(screen.getByText('Live Notes')).toBeInTheDocument();
+        expect(screen.queryByText('Role Intelligence Research')).not.toBeInTheDocument();
+    });
+
+    it('switches to prep workspace when toggled', () => {
+        renderView();
+
+        const toggle = screen.getByRole('switch');
+        fireEvent.click(toggle);
+
+        expect(screen.getByText('Role Intelligence Research')).toBeInTheDocument();
+        expect(screen.queryByText('Live Notes')).not.toBeInTheDocument();
+    });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@google/genai": "^1.7.0",
@@ -22,9 +23,13 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^4.3.2",
+    "jsdom": "^26.0.0",
     "typescript": "~5.8.2",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^2.1.4"
   }
 }

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -251,6 +251,10 @@ const _parseApplication = (app: any): JobApplication => {
                 interview_date: sanitizedInterviewDate,
                 interview_contacts: mappedInterviewContacts,
                 ai_prep_data: safeParseJson(restInterview.ai_prep_data, 'ai_prep_data', interview.interview_id),
+                prep_outline: safeParseJson(restInterview.prep_outline, 'prep_outline', interview.interview_id),
+                live_notes: typeof restInterview.live_notes === 'string' || restInterview.live_notes === null
+                    ? restInterview.live_notes
+                    : undefined,
                 strategic_plan: safeParseJson(restInterview.strategic_plan, 'strategic_plan', interview.interview_id),
                 post_interview_debrief: safeParseJson(restInterview.post_interview_debrief, 'post_interview_debrief', interview.interview_id),
                 strategic_questions_to_ask: Array.isArray(rawQuestions)
@@ -269,7 +273,7 @@ export const getApplications = async (since?: string): Promise<JobApplication[]>
         `&select=*,` +
         `status:statuses(*),` +
         `messages(*),` +
-        `interviews(interview_id,job_application_id,interview_date,interview_type,notes,ai_prep_data,strategic_plan,strategic_opening,post_interview_debrief,strategic_questions_to_ask,story_deck:interview_story_decks(order_index,story_id,custom_notes),interview_contacts(*,contacts(contact_id,first_name,last_name))),` +
+        `interviews(interview_id,job_application_id,interview_date,interview_type,notes,ai_prep_data,prep_outline,live_notes,strategic_plan,strategic_opening,post_interview_debrief,strategic_questions_to_ask,story_deck:interview_story_decks(order_index,story_id,custom_notes),interview_contacts(*,contacts(contact_id,first_name,last_name))),` +
         `offers(*)` +
         `&order=date_applied.desc,created_at.desc`;
     if (since) {
@@ -286,7 +290,7 @@ export const getSingleApplication = async (appId: string): Promise<JobApplicatio
         `&select=*,` +
         `status:statuses(*),` +
         `messages(*),` +
-        `interviews(interview_id,job_application_id,interview_date,interview_type,notes,ai_prep_data,strategic_plan,strategic_opening,post_interview_debrief,strategic_questions_to_ask,story_deck:interview_story_decks(order_index,story_id,custom_notes),interview_contacts(*,contacts(contact_id,first_name,last_name))),` +
+        `interviews(interview_id,job_application_id,interview_date,interview_type,notes,ai_prep_data,prep_outline,live_notes,strategic_plan,strategic_opening,post_interview_debrief,strategic_questions_to_ask,story_deck:interview_story_decks(order_index,story_id,custom_notes),interview_contacts(*,contacts(contact_id,first_name,last_name))),` +
         `offers(*)` +
         `&limit=1`;
     const response = await fetch(url);
@@ -882,6 +886,10 @@ export const getInterviews = async (appId: string): Promise<Interview[]> => {
             interview_date: sanitizedInterviewDate,
             interview_contacts: mappedInterviewContacts,
             ai_prep_data: safeParseJson(interview.ai_prep_data, 'ai_prep_data', interview.interview_id),
+            prep_outline: safeParseJson(interview.prep_outline, 'prep_outline', interview.interview_id),
+            live_notes: typeof interview.live_notes === 'string' || interview.live_notes === null
+                ? interview.live_notes
+                : undefined,
             strategic_plan: safeParseJson(interview.strategic_plan, 'strategic_plan', interview.interview_id),
             post_interview_debrief: safeParseJson(interview.post_interview_debrief, 'post_interview_debrief', interview.interview_id),
             strategic_questions_to_ask: Array.isArray(parsedQuestions) ? parsedQuestions : [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vitest/globals"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,

--- a/types.ts
+++ b/types.ts
@@ -422,12 +422,29 @@ export interface PostInterviewDebrief {
     coaching_recommendations: string[];
 }
 
+export interface InterviewPrepOutline {
+  role_intelligence?: {
+    core_problem?: string;
+    suggested_positioning?: string;
+    key_success_metrics?: string[];
+    role_levers?: string[];
+    potential_blockers?: string[];
+  };
+  jd_insights?: {
+    business_context?: string;
+    strategic_importance?: string;
+    tags?: string[];
+  };
+}
+
 export interface Interview {
   interview_id: string; // uuid
   job_application_id: string;
   interview_date?: string;
   interview_type: string; // e.g., "Phone Screen", "Technical", "Hiring Manager"
   notes?: string;
+  prep_outline?: InterviewPrepOutline | null;
+  live_notes?: string | null;
   ai_prep_data?: InterviewPrep | null;
   strategic_plan?: ConsultativeClosePlan | null;
   strategic_opening?: string | null;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,11 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
+      },
+      test: {
+        globals: true,
+        environment: 'jsdom',
+        setupFiles: './vitest.setup.ts'
       }
     };
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- include the prep_outline and live_notes columns when fetching a single application so the copilot can hydrate its new prep and live note workspaces

## Testing
- npm run build
- npm run test -- --run *(fails: vitest is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a64ea8488330bae6a0f3ebe21f4e