### PR TITLE
Provide local responsive grid shim

### DIFF
--- a/components/InterviewCopilotView.tsx
+++ b/components/InterviewCopilotView.tsx
@@ -1,8 +1,20 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { JobApplication, Interview, StrategicNarrative, StorytellingFormat, StarBody, ScopeBody, WinsBody, SpotlightBody, InterviewPayload, Company, JobProblemAnalysisResult, InterviewPrepOutline, ImpactStory } from '../types';
-import { CheckIcon, GripVerticalIcon, ClipboardDocumentCheckIcon, SparklesIcon, LoadingSpinner } from './IconComponents';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Responsive, WidthProvider } from 'react-grid-layout';
+import type { Layouts, Layout } from 'react-grid-layout';
+import { componentRegistry } from './interview-copilot/componentRegistry';
+import type {
+    JobCheatSheetData,
+    WidgetId,
+    WidgetMode,
+    WidgetState,
+    WidgetRuntimeContext,
+} from './interview-copilot/types';
+import type { JobApplication, Interview, StrategicNarrative, InterviewPayload, Company } from '../types';
+import type { JobProblemAnalysisResult, InterviewPrepOutline } from '../types';
+import { buildHydratedDeck } from '../utils/interviewDeck';
 import { Switch } from './Switch';
-import { HydratedDeckItem, buildHydratedDeck, ensureRoleOnDeck, removeRoleFromDeck, serializeDeck, updateDeckOrder, upsertDeckStory } from '../utils/interviewDeck';
+import { CheckIcon, LoadingSpinner, SparklesIcon } from './IconComponents';
+import { appendUnique, formatTimestamp } from './interview-copilot/utils';
 
 interface InterviewCopilotViewProps {
     application: JobApplication;
@@ -15,45 +27,11 @@ interface InterviewCopilotViewProps {
     onGenerateRecruiterScreenPrep: (app: JobApplication, interview: Interview) => Promise<void>;
 }
 
-const STORY_FORMAT_FIELDS: { [key in StorytellingFormat]: (keyof (StarBody & ScopeBody & WinsBody & SpotlightBody))[] } = {
-    STAR: ['situation', 'task', 'action', 'result'],
-    SCOPE: ['situation', 'complication', 'opportunity', 'product_thinking', 'end_result'],
-    WINS: ['situation', 'what_i_did', 'impact', 'nuance'],
-    SPOTLIGHT: ['situation', 'positive_moment_or_goal', 'observation_opportunity', 'task_action', 'learnings_leverage', 'impact_results', 'growth_grit', 'highlights_key_trait', 'takeaway_tie_in'],
-};
-
-const STORY_FORMAT_COLORS: { [key in StorytellingFormat]: string } = {
-    STAR: 'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-300',
-    SCOPE: 'bg-purple-100 text-purple-800 dark:bg-purple-900/50 dark:text-purple-300',
-    WINS: 'bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300',
-    SPOTLIGHT: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/50 dark:text-yellow-300',
-};
-
-
-const appendUnique = (existing: string, addition: string) => {
-    const trimmedAddition = addition.trim();
-    if (!trimmedAddition) return existing;
-
-    if (!existing.trim()) {
-        return trimmedAddition;
-    }
-
-    if (existing.includes(trimmedAddition)) {
-        return existing;
-    }
-
-    return `${existing.trimEnd()}\n\n${trimmedAddition}`;
-};
-
-const sanitizeListInput = (value: string): string[] =>
-    value
-        .split('\n')
-        .map(item => item.trim())
-        .filter(Boolean);
+const ResponsiveGridLayout = WidthProvider(Responsive);
 
 const buildPrepOutline = (
     analysis?: JobProblemAnalysisResult | null,
-    stored?: InterviewPrepOutline | null
+    stored?: InterviewPrepOutline | null,
 ): InterviewPrepOutline => {
     const defaults: InterviewPrepOutline = {
         role_intelligence: {
@@ -77,10 +55,13 @@ const buildPrepOutline = (
     return {
         role_intelligence: {
             core_problem: stored.role_intelligence?.core_problem ?? defaults.role_intelligence?.core_problem ?? '',
-            suggested_positioning: stored.role_intelligence?.suggested_positioning ?? defaults.role_intelligence?.suggested_positioning ?? '',
-            key_success_metrics: stored.role_intelligence?.key_success_metrics ?? defaults.role_intelligence?.key_success_metrics ?? [],
+            suggested_positioning:
+                stored.role_intelligence?.suggested_positioning ?? defaults.role_intelligence?.suggested_positioning ?? '',
+            key_success_metrics:
+                stored.role_intelligence?.key_success_metrics ?? defaults.role_intelligence?.key_success_metrics ?? [],
             role_levers: stored.role_intelligence?.role_levers ?? defaults.role_intelligence?.role_levers ?? [],
-            potential_blockers: stored.role_intelligence?.potential_blockers ?? defaults.role_intelligence?.potential_blockers ?? [],
+            potential_blockers:
+                stored.role_intelligence?.potential_blockers ?? defaults.role_intelligence?.potential_blockers ?? [],
         },
         jd_insights: {
             business_context: stored.jd_insights?.business_context ?? defaults.jd_insights?.business_context ?? '',
@@ -90,837 +71,51 @@ const buildPrepOutline = (
     };
 };
 
-const CoPilotSection = ({ title, children, className = '' }: { title: string, children: React.ReactNode, className?: string }) => (
-    <div className={`bg-white dark:bg-slate-800 p-3 rounded-lg shadow-sm border border-slate-200 dark:border-slate-700 ${className}`}>
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-2">{title}</h3>
-        <div className="space-y-2">
-            {children}
-        </div>
-    </div>
-);
+const mergeLayouts = (registryLayouts: Layouts[]): Layouts => {
+    const result: Layouts = { lg: [], md: [], sm: [] };
+    registryLayouts.forEach((layoutSet) => {
+        (Object.keys(layoutSet) as (keyof Layouts)[]).forEach((breakpoint) => {
+            const layouts = layoutSet[breakpoint] || [];
+            result[breakpoint] = result[breakpoint] || [];
+            result[breakpoint]!.push(...layouts.map((layout) => ({ ...layout })));
+        });
+    });
+    return result;
+};
 
-type CoverageState = { metrics: Set<string>; levers: Set<string>; blockers: Set<string>; };
-type CoverageCategory = keyof CoverageState;
+const buildDefaultLayouts = (): Layouts =>
+    mergeLayouts(componentRegistry.map((config) => config.defaultLayouts));
 
-const createEmptyCoverageState = (): CoverageState => ({
-    metrics: new Set<string>(),
-    levers: new Set<string>(),
-    blockers: new Set<string>(),
-});
-
-const pruneCoverageSelections = (
-    state: CoverageState,
-    metrics: string[],
-    levers: string[],
-    blockers: string[],
-): CoverageState => ({
-    metrics: new Set(metrics.filter(metric => state.metrics.has(metric))),
-    levers: new Set(levers.filter(lever => state.levers.has(lever))),
-    blockers: new Set(blockers.filter(blocker => state.blockers.has(blocker))),
-});
-
-const ImpactStoryTrigger = ({
-    item,
-    jobAnalysis,
-    onAppendNotepad,
-    isEditMode,
-    activeRole,
-    onNoteChange,
-    onDragStart,
-    onDragEnter,
-    onDragEnd,
-    onRemove,
-}: {
-    item: HydratedDeckItem;
-    jobAnalysis?: JobProblemAnalysisResult;
-    onAppendNotepad: (text: string) => void;
-    isEditMode: boolean;
-    activeRole: string;
-    onNoteChange: (storyId: string, field: string, value: string) => void;
-    onDragStart?: (storyId: string) => void;
-    onDragEnter?: (storyId: string) => void;
-    onDragEnd?: () => void;
-    onRemove?: (storyId: string) => void;
-}) => {
-    const story = item.story;
-    const formatName = (story?.format || 'STAR') as StorytellingFormat;
-    const badgeColor = STORY_FORMAT_COLORS[formatName];
-    const orderedFields = STORY_FORMAT_FIELDS[formatName] || [];
-    const defaultNotes = item.custom_notes.default || {};
-    const roleNotes = item.custom_notes[activeRole] || {};
-
-    const cues = jobAnalysis
-        ? [
-              ...(jobAnalysis.key_success_metrics || []).map((value) => ({
-                  label: 'Success Metric',
-                  value,
-              })),
-              ...(jobAnalysis.role_levers || []).map((value) => ({
-                  label: 'Lever',
-                  value,
-              })),
-              ...(jobAnalysis.potential_blockers || []).map((value) => ({
-                  label: 'Blocker',
-                  value,
-              })),
-          ].slice(0, 3)
-        : [];
-
-    const readableLabel = (key: string) => key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
-
-    if (isEditMode) {
-        const dragHandlers = {
-            draggable: true,
-            onDragStart: (event: React.DragEvent<HTMLDivElement>) => {
-                event.dataTransfer.effectAllowed = 'move';
-                onDragStart?.(item.story_id);
-            },
-            onDragOver: (event: React.DragEvent<HTMLDivElement>) => {
-                event.preventDefault();
-                onDragEnter?.(item.story_id);
-            },
-            onDrop: (event: React.DragEvent<HTMLDivElement>) => {
-                event.preventDefault();
-                onDragEnd?.();
-            },
-            onDragEnd: () => onDragEnd?.(),
-        };
-
-        return (
-            <div
-                className="p-3 rounded-md bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-700 space-y-3"
-                {...dragHandlers}
-            >
-                <div className="flex items-start justify-between gap-2">
-                    <div className="flex items-center gap-2">
-                        <span className="text-slate-400 cursor-grab" aria-hidden="true">
-                            <GripVerticalIcon className="w-4 h-4" />
-                        </span>
-                        <div>
-                            <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">
-                                {story ? story.story_title : 'Story unavailable'}
-                            </p>
-                            <span className={`inline-flex text-xs font-mono px-1.5 py-0.5 rounded ${badgeColor}`}>
-                                {formatName}
-                            </span>
-                        </div>
-                    </div>
-                    {onRemove && (
-                        <button
-                            type="button"
-                            onClick={() => onRemove(item.story_id)}
-                            className="text-xs font-semibold text-red-600 hover:text-red-700 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-red-500 rounded"
-                        >
-                            Remove
-                        </button>
-                    )}
-                </div>
-                {story ? (
-                    <div className="space-y-2">
-                        {orderedFields.map(field => {
-                            const key = field as keyof (StarBody & ScopeBody & WinsBody & SpotlightBody);
-                            const fieldName = key as unknown as string;
-                            const placeholder = defaultNotes[fieldName] || '';
-                            const value = roleNotes[fieldName] || '';
-                            return (
-                                <div key={fieldName}>
-                                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                                        {readableLabel(fieldName)}
-                                    </label>
-                                    <textarea
-                                        rows={2}
-                                        value={value}
-                                        placeholder={placeholder}
-                                        onChange={(e) => onNoteChange(item.story_id, fieldName, e.target.value)}
-                                        className="w-full mt-1 p-2 text-xs font-mono bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                                    />
-                                    {activeRole !== 'default' && placeholder && (
-                                        <p className="text-[10px] text-slate-400 dark:text-slate-500 mt-1">Default: {placeholder}</p>
-                                    )}
-                                </div>
-                            );
-                        })}
-                    </div>
-                ) : (
-                    <p className="text-xs text-amber-600">
-                        This story is no longer part of the strategic narrative. Add it back to the narrative or remove it from this deck.
-                    </p>
-                )}
-            </div>
-        );
-    }
-
-    const noteParagraphs = orderedFields
-        .map(field => {
-            const key = field as keyof (StarBody & ScopeBody & WinsBody & SpotlightBody);
-            const fieldName = key as unknown as string;
-            const value = roleNotes[fieldName] ?? defaultNotes[fieldName];
-            if (!value) {
-                return null;
+const buildDefaultHeights = (): Record<string, Record<WidgetId, number>> => {
+    const heights: Record<string, Record<WidgetId, number>> = { lg: {}, md: {}, sm: {} };
+    componentRegistry.forEach((config) => {
+        (Object.keys(config.defaultLayouts) as (keyof Layouts)[]).forEach((breakpoint) => {
+            const layout = config.defaultLayouts[breakpoint]?.find((item) => item.i === config.id);
+            if (layout) {
+                heights[breakpoint] = heights[breakpoint] || {};
+                heights[breakpoint]![config.id] = layout.h;
             }
-            return (
-                <p key={fieldName} className="mb-1">
-                    <strong>{readableLabel(fieldName)}:</strong> {value}
-                </p>
-            );
-        })
-        .filter(Boolean);
-
-    return (
-        <details className="p-2 rounded-md bg-slate-200 dark:bg-slate-700">
-            <summary className="w-full text-left text-sm font-semibold text-slate-800 dark:text-slate-200 flex justify-between items-center cursor-pointer">
-                <span className="truncate pr-2">{story ? story.story_title : 'Story unavailable'}</span>
-                <span className={`text-xs font-mono px-1.5 py-0.5 rounded flex-shrink-0 ${badgeColor}`}>{formatName}</span>
-            </summary>
-            <div className="mt-2 pt-2 border-t border-slate-300 dark:border-slate-600 text-xs text-slate-600 dark:text-slate-300 whitespace-pre-wrap font-mono">
-                {noteParagraphs.length > 0 ? noteParagraphs : <p className="italic">No speaker notes for this role yet.</p>}
-            </div>
-            {cues.length > 0 && (
-                <div className="mt-3 rounded-md border border-slate-300 dark:border-slate-600 bg-slate-100 dark:bg-slate-800/70 p-2 text-xs text-slate-600 dark:text-slate-300">
-                    <p className="font-semibold uppercase tracking-wide text-[10px] text-slate-500 dark:text-slate-400">Align this story to…</p>
-                    <ul className="mt-2 space-y-2">
-                        {cues.map(({ label, value }, index) => {
-                            const prompt = `Emphasize how you solved ${value}.`;
-                            const stub = `Emphasize how I solved ${value} by `;
-                            return (
-                                <li key={`${label}-${index}`} className="flex items-start justify-between gap-2">
-                                    <div className="flex-1">
-                                        <div className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                                            <span className="inline-flex h-1.5 w-1.5 rounded-full bg-indigo-500" aria-hidden="true" />
-                                            {label}
-                                        </div>
-                                        <p className="text-[11px] font-medium text-slate-700 dark:text-slate-200">{prompt}</p>
-                                    </div>
-                                    <button
-                                        type="button"
-                                        onClick={() => onAppendNotepad(stub)}
-                                        className="flex-shrink-0 inline-flex items-center rounded-md border border-slate-300 dark:border-slate-600 px-2 py-1 text-[10px] font-semibold text-indigo-600 dark:text-indigo-300 hover:bg-slate-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-500"
-                                    >
-                                        Add stub
-                                    </button>
-                                </li>
-                            );
-                        })}
-                    </ul>
-                </div>
-            )}
-        </details>
-    );
+        });
+    });
+    return heights;
 };
 
-interface PrepWorkspaceProps {
-    interview: Interview;
-    jobAnalysis?: JobProblemAnalysisResult | null;
-    activeRole: string;
-    availableRoles: string[];
-    onRoleChange: (role: string) => void;
-    onAddRole: () => void;
-    onRemoveRole: (role: string) => void;
-    newRoleName: string;
-    onNewRoleNameChange: (value: string) => void;
-    availableStories: ImpactStory[];
-    storyToAdd: string;
-    onStoryToAddChange: (value: string) => void;
-    onAddStory: () => void;
-    storyDeck: HydratedDeckItem[];
-    onNoteChange: (storyId: string, field: string, value: string) => void;
-    onDragStart: (storyId: string) => void;
-    onDragEnter: (storyId: string) => void;
-    onDragEnd: () => void;
-    onRemoveStory: (storyId: string) => void;
-    editableOpening: string;
-    onChangeOpening: (value: string) => void;
-    editableQuestions: string;
-    onChangeQuestions: (value: string) => void;
-    prepOutline: InterviewPrepOutline;
-    onUpdateRoleIntelligence: (
-        field: keyof NonNullable<InterviewPrepOutline['role_intelligence']>,
-        value: string,
-        isList?: boolean,
-    ) => void;
-    onUpdateJdInsights: (
-        field: keyof NonNullable<InterviewPrepOutline['jd_insights']>,
-        value: string,
-        isList?: boolean,
-    ) => void;
-}
+const pruneCoverage = (values: string[], covered: string[]): string[] => {
+    const set = new Set(values);
+    return covered.filter((value) => set.has(value));
+};
 
-const PrepWorkspace = ({
+export const InterviewCopilotView = ({
+    application,
     interview,
-    jobAnalysis,
-    activeRole,
-    availableRoles,
-    onRoleChange,
-    onAddRole,
-    onRemoveRole,
-    newRoleName,
-    onNewRoleNameChange,
-    availableStories,
-    storyToAdd,
-    onStoryToAddChange,
-    onAddStory,
-    storyDeck,
-    onNoteChange,
-    onDragStart,
-    onDragEnter,
-    onDragEnd,
-    onRemoveStory,
-    editableOpening,
-    onChangeOpening,
-    editableQuestions,
-    onChangeQuestions,
-    prepOutline,
-    onUpdateRoleIntelligence,
-    onUpdateJdInsights,
-}: PrepWorkspaceProps) => {
-    const roleIntelligence = prepOutline.role_intelligence || {};
-    const jdInsights = prepOutline.jd_insights || {};
-
-    const keyMetricsValue = (roleIntelligence.key_success_metrics || []).join('\n');
-    const leversValue = (roleIntelligence.role_levers || []).join('\n');
-    const blockersValue = (roleIntelligence.potential_blockers || []).join('\n');
-    const tagsValue = (jdInsights.tags || []).join('\n');
-
-    return (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 h-full">
-            <div className="md:col-span-2 overflow-y-auto space-y-3 pr-0 md:pr-2">
-                <CoPilotSection title="Strategic Opening Draft">
-                    <textarea
-                        value={editableOpening}
-                        onChange={(e) => onChangeOpening(e.target.value)}
-                        rows={5}
-                        className="w-full mt-1 p-2 text-sm text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-700 rounded-md"
-                    />
-                </CoPilotSection>
-                <CoPilotSection title="Impact Story Drafting">
-                    <div className="space-y-3">
-                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                            <div className="flex flex-wrap items-center gap-2">
-                                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Persona</span>
-                                <select
-                                    value={activeRole}
-                                    onChange={(e) => onRoleChange(e.target.value)}
-                                    className="rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-xs px-2 py-1 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                                >
-                                    {availableRoles.map(role => (
-                                        <option key={role} value={role}>{role}</option>
-                                    ))}
-                                </select>
-                                {activeRole !== 'default' && (
-                                    <button
-                                        type="button"
-                                        onClick={() => onRemoveRole(activeRole)}
-                                        className="inline-flex items-center rounded-md border border-slate-300 dark:border-slate-600 px-2 py-1 text-[10px] font-semibold text-red-600 dark:text-red-300 hover:bg-slate-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-red-500"
-                                    >
-                                        Remove Role
-                                    </button>
-                                )}
-                            </div>
-                            <div className="flex flex-wrap items-center gap-2">
-                                <input
-                                    type="text"
-                                    value={newRoleName}
-                                    onChange={(e) => onNewRoleNameChange(e.target.value)}
-                                    placeholder="Add interviewer persona"
-                                    className="w-48 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                                />
-                                <button
-                                    type="button"
-                                    onClick={onAddRole}
-                                    disabled={!newRoleName.trim()}
-                                    className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1 text-xs font-semibold text-white shadow-sm hover:bg-indigo-700 disabled:bg-indigo-300"
-                                >
-                                    Add Role
-                                </button>
-                            </div>
-                        </div>
-                        {availableStories.length > 0 && (
-                            <div className="flex flex-wrap items-center gap-2">
-                                <select
-                                    value={storyToAdd}
-                                    onChange={(e) => onStoryToAddChange(e.target.value)}
-                                    className="rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-xs px-2 py-1 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                                >
-                                    <option value="">Add narrative story…</option>
-                                    {availableStories.map(story => (
-                                        <option key={story.story_id} value={story.story_id}>{story.story_title}</option>
-                                    ))}
-                                </select>
-                                <button
-                                    type="button"
-                                    onClick={onAddStory}
-                                    disabled={!storyToAdd}
-                                    className="inline-flex items-center rounded-md bg-green-600 px-3 py-1 text-xs font-semibold text-white shadow-sm hover:bg-green-700 disabled:bg-green-300"
-                                >
-                                    Add Story
-                                </button>
-                            </div>
-                        )}
-                        <div className="space-y-2">
-                            {storyDeck.length > 0 ? (
-                                storyDeck.map(item => (
-                                    <ImpactStoryTrigger
-                                        key={item.story_id}
-                                        item={item}
-                                        jobAnalysis={jobAnalysis}
-                                        onAppendNotepad={() => undefined}
-                                        isEditMode
-                                        activeRole={activeRole}
-                                        onNoteChange={onNoteChange}
-                                        onDragStart={onDragStart}
-                                        onDragEnter={onDragEnter}
-                                        onDragEnd={onDragEnd}
-                                        onRemove={onRemoveStory}
-                                    />
-                                ))
-                            ) : (
-                                <p className="text-xs text-slate-500 dark:text-slate-400 text-center">No impact stories defined.</p>
-                            )}
-                        </div>
-                    </div>
-                </CoPilotSection>
-                <CoPilotSection title="Consultative Close Highlights">
-                    <ul className="list-disc pl-4 text-sm space-y-1 text-slate-700 dark:text-slate-300">
-                        {(interview.strategic_plan?.key_talking_points || []).map((point, i) => (
-                            <li key={i}>{point}</li>
-                        ))}
-                    </ul>
-                </CoPilotSection>
-                <CoPilotSection title="Question Drafting">
-                    <textarea
-                        value={editableQuestions}
-                        onChange={(e) => onChangeQuestions(e.target.value)}
-                        rows={8}
-                        className="w-full mt-1 p-2 text-sm text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-700 rounded-md"
-                    />
-                </CoPilotSection>
-            </div>
-            <aside className="md:col-span-1 overflow-y-auto space-y-3 pl-0 md:pl-2">
-                <CoPilotSection title="Role Intelligence Research">
-                    <div className="space-y-3 text-xs text-slate-600 dark:text-slate-300">
-                        <div>
-                            <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Core Problem</label>
-                            <textarea
-                                value={roleIntelligence.core_problem || ''}
-                                onChange={(e) => onUpdateRoleIntelligence('core_problem', e.target.value)}
-                                rows={3}
-                                className="w-full mt-1 p-2 text-xs font-mono bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-md"
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Suggested Positioning</label>
-                            <textarea
-                                value={roleIntelligence.suggested_positioning || ''}
-                                onChange={(e) => onUpdateRoleIntelligence('suggested_positioning', e.target.value)}
-                                rows={3}
-                                className="w-full mt-1 p-2 text-xs font-mono bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-md"
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Key Success Metrics</label>
-                            <textarea
-                                value={keyMetricsValue}
-                                onChange={(e) => onUpdateRoleIntelligence('key_success_metrics', e.target.value, true)}
-                                rows={4}
-                                className="w-full mt-1 p-2 text-xs font-mono bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-md"
-                                placeholder="One metric per line"
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Role Levers</label>
-                            <textarea
-                                value={leversValue}
-                                onChange={(e) => onUpdateRoleIntelligence('role_levers', e.target.value, true)}
-                                rows={4}
-                                className="w-full mt-1 p-2 text-xs font-mono bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-md"
-                                placeholder="One lever per line"
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Potential Blockers</label>
-                            <textarea
-                                value={blockersValue}
-                                onChange={(e) => onUpdateRoleIntelligence('potential_blockers', e.target.value, true)}
-                                rows={4}
-                                className="w-full mt-1 p-2 text-xs font-mono bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-md"
-                                placeholder="One blocker per line"
-                            />
-                        </div>
-                    </div>
-                </CoPilotSection>
-                <CoPilotSection title="JD Insights">
-                    <div className="space-y-3 text-xs text-slate-600 dark:text-slate-300">
-                        <div>
-                            <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Business Context</label>
-                            <textarea
-                                value={jdInsights.business_context || ''}
-                                onChange={(e) => onUpdateJdInsights('business_context', e.target.value)}
-                                rows={3}
-                                className="w-full mt-1 p-2 text-xs font-mono bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-md"
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Strategic Importance</label>
-                            <textarea
-                                value={jdInsights.strategic_importance || ''}
-                                onChange={(e) => onUpdateJdInsights('strategic_importance', e.target.value)}
-                                rows={3}
-                                className="w-full mt-1 p-2 text-xs font-mono bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-md"
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Focus Tags</label>
-                            <textarea
-                                value={tagsValue}
-                                onChange={(e) => onUpdateJdInsights('tags', e.target.value, true)}
-                                rows={3}
-                                className="w-full mt-1 p-2 text-xs font-mono bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-md"
-                                placeholder="One tag per line"
-                            />
-                        </div>
-                    </div>
-                </CoPilotSection>
-            </aside>
-        </div>
-    );
-};
-
-interface LiveRundownProps {
-    interview: Interview;
-    editableOpening: string;
-    prepOutline: InterviewPrepOutline;
-    questionList: string[];
-    askedQuestions: Set<string>;
-    onToggleQuestion: (question: string) => void;
-    storyDeck: HydratedDeckItem[];
-    activeRole: string;
-    availableRoles: string[];
-    onRoleChange: (role: string) => void;
-    jobAnalysis?: JobProblemAnalysisResult | null;
-    onQuickAdd: (text: string) => void;
-    keyMetrics: string[];
-    roleLevers: string[];
-    potentialBlockers: string[];
-    covered: CoverageState;
-    toggleCoverage: (category: CoverageCategory, value: string) => void;
-    resetCoverage: () => void;
-    interviewer?: { first_name: string; last_name: string } | undefined;
-    coveragePercent: number;
-    roleTags: string[];
-}
-
-const LiveRundown = ({
-    interview,
-    editableOpening,
-    prepOutline,
-    questionList,
-    askedQuestions,
-    onToggleQuestion,
-    storyDeck,
-    activeRole,
-    availableRoles,
-    onRoleChange,
-    jobAnalysis,
-    onQuickAdd,
-    keyMetrics,
-    roleLevers,
-    potentialBlockers,
-    covered,
-    toggleCoverage,
-    resetCoverage,
-    interviewer,
-    coveragePercent,
-    roleTags,
-}: LiveRundownProps) => {
-    const roleIntelligence = prepOutline.role_intelligence || {};
-    const jdInsights = prepOutline.jd_insights || {};
-
-    const cheatSheetItems = [
-        roleIntelligence.core_problem
-            ? { label: 'Core Problem', value: roleIntelligence.core_problem }
-            : null,
-        jdInsights.business_context
-            ? { label: 'Business Context', value: jdInsights.business_context }
-            : null,
-        jdInsights.strategic_importance
-            ? { label: 'Strategic Importance', value: jdInsights.strategic_importance }
-            : null,
-        roleIntelligence.suggested_positioning
-            ? { label: 'Suggested Positioning', value: roleIntelligence.suggested_positioning }
-            : null,
-    ].filter(Boolean) as { label: string; value: string }[];
-
-    const clarifyingLines = [
-        'To make sure I tailor my answers, could we clarify:',
-        roleIntelligence.core_problem
-            ? `• Are we aligned that the core challenge is "${roleIntelligence.core_problem}"?`
-            : null,
-        (roleIntelligence.key_success_metrics || []).length
-            ? `• Which success metrics matter most right now? (${roleIntelligence.key_success_metrics!.join(', ')})`
-            : null,
-        (roleIntelligence.role_levers || []).length
-            ? `• Where do you need the most leverage today? (${roleIntelligence.role_levers!.join(', ')})`
-            : null,
-        (roleIntelligence.potential_blockers || []).length
-            ? `• What blockers are slowing progress? (${roleIntelligence.potential_blockers!.join(', ')})`
-            : null,
-    ].filter(Boolean) as string[];
-
-    const clarifyingPrompt = clarifyingLines.join('\n');
-
-    const metricsList = keyMetrics.map((metric, index) => {
-        const id = `metric-${index}`;
-        const isCovered = covered.metrics.has(metric);
-        return (
-            <li key={id}>
-                <button
-                    type="button"
-                    onClick={() => toggleCoverage('metrics', metric)}
-                    className={`flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm transition ${isCovered ? 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-200' : 'hover:bg-slate-200 dark:hover:bg-slate-700/80 text-slate-700 dark:text-slate-200'}`}
-                >
-                    <span className={`flex h-4 w-4 items-center justify-center rounded border ${isCovered ? 'border-green-600 bg-green-600 text-white' : 'border-slate-400 text-transparent'}`}>
-                        <CheckIcon className="h-3 w-3" />
-                    </span>
-                    <span className={isCovered ? 'line-through' : ''}>{metric}</span>
-                </button>
-            </li>
-        );
-    });
-
-    const leversList = roleLevers.map((lever, index) => {
-        const isCovered = covered.levers.has(lever);
-        return (
-            <li key={`lever-${index}`}>
-                <button
-                    type="button"
-                    onClick={() => toggleCoverage('levers', lever)}
-                    className={`flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm transition ${isCovered ? 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-200' : 'hover:bg-slate-200 dark:hover:bg-slate-700/80 text-slate-700 dark:text-slate-200'}`}
-                >
-                    <span className={`flex h-4 w-4 items-center justify-center rounded border ${isCovered ? 'border-green-600 bg-green-600 text-white' : 'border-slate-400 text-transparent'}`}>
-                        <CheckIcon className="h-3 w-3" />
-                    </span>
-                    <span className={isCovered ? 'line-through' : ''}>{lever}</span>
-                </button>
-            </li>
-        );
-    });
-
-    const blockersList = potentialBlockers.map((blocker, index) => {
-        const isCovered = covered.blockers.has(blocker);
-        return (
-            <li key={`blocker-${index}`}>
-                <button
-                    type="button"
-                    onClick={() => toggleCoverage('blockers', blocker)}
-                    className={`flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm transition ${isCovered ? 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-200' : 'hover:bg-slate-200 dark:hover:bg-slate-700/80 text-slate-700 dark:text-slate-200'}`}
-                >
-                    <span className={`flex h-4 w-4 items-center justify-center rounded border ${isCovered ? 'border-green-600 bg-green-600 text-white' : 'border-slate-400 text-transparent'}`}>
-                        <CheckIcon className="h-3 w-3" />
-                    </span>
-                    <span className={isCovered ? 'line-through' : ''}>{blocker}</span>
-                </button>
-            </li>
-        );
-    });
-
-    return (
-        <div className="md:col-span-2 overflow-y-auto space-y-3 pr-0 md:pr-2">
-            <CoPilotSection title="Job Cheat Sheet">
-                <div className="space-y-2 text-sm text-slate-700 dark:text-slate-200">
-                    {cheatSheetItems.length > 0 ? (
-                        cheatSheetItems.map(item => (
-                            <div key={item.label}>
-                                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{item.label}</p>
-                                <p className="mt-1 whitespace-pre-wrap">{item.value}</p>
-                            </div>
-                        ))
-                    ) : (
-                        <p className="text-sm text-slate-500 dark:text-slate-400">Add research in prep mode to populate this cheat sheet.</p>
-                    )}
-                    {roleTags.length > 0 && (
-                        <div>
-                            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Focus Tags</p>
-                            <p className="mt-1 text-sm">{roleTags.join(', ')}</p>
-                        </div>
-                    )}
-                </div>
-            </CoPilotSection>
-            <CoPilotSection title="Clarifying Prompt Launcher">
-                <div className="space-y-2">
-                    <div className="rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/60 p-2 text-xs font-mono text-slate-700 dark:text-slate-200 whitespace-pre-wrap">
-                        {clarifyingPrompt || 'Draft clarifying prompts in prep mode to launch them quickly during the interview.'}
-                    </div>
-                    {clarifyingPrompt && (
-                        <button
-                            type="button"
-                            onClick={() => onQuickAdd(clarifyingPrompt)}
-                            className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-indigo-700"
-                        >
-                            <SparklesIcon className="h-4 w-4" /> Send to Notes
-                        </button>
-                    )}
-                </div>
-            </CoPilotSection>
-            <CoPilotSection title="Top of Mind">
-                <div className="text-xs space-y-1 text-slate-600 dark:text-slate-300">
-                    <p><strong>Interviewing with:</strong> {interviewer ? `${interviewer.first_name} ${interviewer.last_name}` : 'TBD'}</p>
-                    <p><strong>Format:</strong> {interview.interview_type}</p>
-                </div>
-            </CoPilotSection>
-            <CoPilotSection title="Strategic Opening">
-                <p className="text-sm italic text-slate-700 dark:text-slate-300 whitespace-pre-wrap">{editableOpening}</p>
-            </CoPilotSection>
-            <CoPilotSection title="Question Arsenal">
-                <div className="space-y-2">
-                    {questionList.length > 0 ? (
-                        questionList.map((question, index) => {
-                            const id = `live-question-${index}`;
-                            return (
-                                <div key={id} className="relative flex items-start">
-                                    <div className="flex h-6 items-center">
-                                        <input
-                                            id={id}
-                                            type="checkbox"
-                                            checked={askedQuestions.has(question)}
-                                            onChange={() => onToggleQuestion(question)}
-                                            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                                        />
-                                    </div>
-                                    <div className="ml-3 text-sm leading-6">
-                                        <label htmlFor={id} className={`text-slate-700 dark:text-slate-300 ${askedQuestions.has(question) ? 'line-through text-slate-400 dark:text-slate-500' : ''}`}>
-                                            {question}
-                                        </label>
-                                    </div>
-                                </div>
-                            );
-                        })
-                    ) : (
-                        <p className="text-sm text-slate-500 dark:text-slate-400">Add strategic questions in prep mode.</p>
-                    )}
-                </div>
-            </CoPilotSection>
-            <CoPilotSection title="Impact Story Triggers">
-                <div className="space-y-3">
-                    <div className="flex items-center gap-2">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Persona</span>
-                        <select
-                            value={activeRole}
-                            onChange={(e) => onRoleChange(e.target.value)}
-                            className="rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-xs px-2 py-1 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                        >
-                            {availableRoles.map(role => (
-                                <option key={role} value={role}>{role}</option>
-                            ))}
-                        </select>
-                    </div>
-                    <div className="space-y-2">
-                        {storyDeck.length > 0 ? (
-                            storyDeck.map(item => (
-                                <ImpactStoryTrigger
-                                    key={item.story_id}
-                                    item={item}
-                                    jobAnalysis={jobAnalysis}
-                                    onAppendNotepad={onQuickAdd}
-                                    isEditMode={false}
-                                    activeRole={activeRole}
-                                    onNoteChange={() => undefined}
-                                />
-                            ))
-                        ) : (
-                            <p className="text-xs text-slate-500 dark:text-slate-400 text-center">No impact stories defined.</p>
-                        )}
-                    </div>
-                </div>
-            </CoPilotSection>
-            <CoPilotSection title="Live Checklist">
-                <div className="space-y-3">
-                    <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
-                        <span>Coverage</span>
-                        <span>{coveragePercent}% complete</span>
-                    </div>
-                    <div className="space-y-4">
-                        <div>
-                            <div className="flex items-center justify-between">
-                                <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Key Success Metrics</p>
-                                {keyMetrics.length > 0 && (
-                                    <button
-                                        type="button"
-                                        onClick={() => onQuickAdd(`Key Success Metrics:\n${keyMetrics.map(metric => `• ${metric}`).join('\n')}`)}
-                                        className="inline-flex items-center gap-1 rounded-md border border-slate-300 dark:border-slate-600 px-2 py-1 text-[10px] font-semibold text-slate-600 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
-                                    >
-                                        <ClipboardDocumentCheckIcon className="h-4 w-4" /> Copy
-                                    </button>
-                                )}
-                            </div>
-                            <ul className="mt-2 space-y-1">{metricsList}</ul>
-                        </div>
-                        <div>
-                            <div className="flex items-center justify-between">
-                                <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Levers</p>
-                                {roleLevers.length > 0 && (
-                                    <button
-                                        type="button"
-                                        onClick={() => onQuickAdd(`Levers:\n${roleLevers.map(lever => `• ${lever}`).join('\n')}`)}
-                                        className="inline-flex items-center gap-1 rounded-md border border-slate-300 dark:border-slate-600 px-2 py-1 text-[10px] font-semibold text-slate-600 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
-                                    >
-                                        <ClipboardDocumentCheckIcon className="h-4 w-4" /> Copy
-                                    </button>
-                                )}
-                            </div>
-                            <ul className="mt-2 space-y-1">{leversList}</ul>
-                        </div>
-                        <div>
-                            <div className="flex items-center justify-between">
-                                <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Potential Blockers</p>
-                                {potentialBlockers.length > 0 && (
-                                    <button
-                                        type="button"
-                                        onClick={() => onQuickAdd(`Potential Blockers:\n${potentialBlockers.map(blocker => `• ${blocker}`).join('\n')}`)}
-                                        className="inline-flex items-center gap-1 rounded-md border border-slate-300 dark:border-slate-600 px-2 py-1 text-[10px] font-semibold text-slate-600 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
-                                    >
-                                        <ClipboardDocumentCheckIcon className="h-4 w-4" /> Copy
-                                    </button>
-                                )}
-                            </div>
-                            <ul className="mt-2 space-y-1">{blockersList}</ul>
-                        </div>
-                        <button
-                            type="button"
-                            onClick={resetCoverage}
-                            className="inline-flex items-center gap-1 rounded-md border border-slate-300 dark:border-slate-600 px-2 py-1 text-[10px] font-semibold text-slate-600 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
-                        >
-                            Reset Checklist
-                        </button>
-                    </div>
-                </div>
-            </CoPilotSection>
-            <CoPilotSection title="Hot Leads (30-60-90 Plan)">
-                <ul className="list-disc pl-4 text-sm space-y-1 text-slate-700 dark:text-slate-300">
-                    {(interview.strategic_plan?.key_talking_points || []).map((point, i) => (
-                        <li key={i}>{point}</li>
-                    ))}
-                </ul>
-            </CoPilotSection>
-        </div>
-    );
-};
-
-export const InterviewCopilotView = ({ application, interview, company, activeNarrative, onBack, onSaveInterview, onGenerateInterviewPrep, onGenerateRecruiterScreenPrep }: InterviewCopilotViewProps) => {
-    const [isEditMode, setIsEditMode] = useState(false);
-    const [editableOpening, setEditableOpening] = useState('');
-    const [editableQuestions, setEditableQuestions] = useState('');
-    const [liveNotes, setLiveNotes] = useState('');
-    const [askedQuestions, setAskedQuestions] = useState<Set<string>>(new Set());
-    const [storyDeck, setStoryDeck] = useState<HydratedDeckItem[]>(() => buildHydratedDeck(interview, activeNarrative));
-    const [activeRole, setActiveRole] = useState('default');
-    const [draggingStoryId, setDraggingStoryId] = useState<string | null>(null);
-    const [newRoleName, setNewRoleName] = useState('');
-    const [storyToAdd, setStoryToAdd] = useState('');
-    const [covered, setCovered] = useState<CoverageState>(createEmptyCoverageState);
-    const [prepOutline, setPrepOutline] = useState<InterviewPrepOutline>(() =>
-        buildPrepOutline(application.job_problem_analysis_result, interview.prep_outline)
-    );
-
+    company,
+    activeNarrative,
+    onBack,
+    onSaveInterview,
+    onGenerateInterviewPrep,
+    onGenerateRecruiterScreenPrep,
+}: InterviewCopilotViewProps) => {
+    const [mode, setMode] = useState<WidgetMode>('live');
     const [isSaving, setIsSaving] = useState(false);
     const [saveSuccess, setSaveSuccess] = useState(false);
     const [isSavingNotes, setIsSavingNotes] = useState(false);
@@ -928,398 +123,380 @@ export const InterviewCopilotView = ({ application, interview, company, activeNa
     const [isGeneratingPrep, setIsGeneratingPrep] = useState(false);
 
     const jobAnalysis = useMemo(() => application.job_problem_analysis_result, [application]);
-
-    useEffect(() => {
-        setStoryDeck(buildHydratedDeck(interview, activeNarrative));
-    }, [interview, activeNarrative]);
-
-    useEffect(() => {
-        const opening = interview.strategic_opening || `"I'm a product leader who excels at ${activeNarrative.positioning_statement}. My understanding is the core challenge here is ${application.job_problem_analysis_result?.core_problem_analysis.core_problem}. That's a problem I'm familiar with from my time when I ${activeNarrative.impact_story_title}."`;
-        setEditableOpening(opening);
-        setEditableQuestions((interview.strategic_questions_to_ask || []).join('\n'));
-        setLiveNotes(interview.live_notes || '');
-        setPrepOutline(buildPrepOutline(application.job_problem_analysis_result, interview.prep_outline));
-    }, [interview, activeNarrative, application]);
-
-    const availableRoles = useMemo(() => {
-        const roles = new Set<string>();
-        storyDeck.forEach(item => {
-            Object.keys(item.custom_notes).forEach(role => roles.add(role));
-        });
-        if (roles.size === 0) {
-            roles.add('default');
-        }
-        return Array.from(roles);
-    }, [storyDeck]);
-
-    const questionList = useMemo(
-        () => editableQuestions.split('\n').map(question => question.trim()).filter(Boolean),
-        [editableQuestions]
+    const prepOutline = useMemo(
+        () => buildPrepOutline(jobAnalysis, interview.prep_outline),
+        [jobAnalysis, interview.prep_outline],
+    );
+    const storyDeck = useMemo(
+        () => buildHydratedDeck(interview, activeNarrative),
+        [interview, activeNarrative],
     );
 
+    const defaultLayouts = useMemo(() => buildDefaultLayouts(), []);
+    const defaultHeights = useMemo(() => buildDefaultHeights(), []);
+
+    const initialWidgetStates = useMemo(() => {
+        const context = {
+            application,
+            interview,
+            narrative: activeNarrative,
+            prepOutline,
+            storyDeck,
+            jobAnalysis,
+        };
+        return componentRegistry.reduce<Record<WidgetId, WidgetState<any>>>((acc, config) => {
+            acc[config.id] = { ...config.getInitialState(context), lastUpdated: interview.interview_date || undefined };
+            return acc;
+        }, {} as Record<WidgetId, WidgetState<any>>);
+    }, [application, interview, activeNarrative, prepOutline, storyDeck, jobAnalysis]);
+
+    const [widgetStates, setWidgetStates] = useState<Record<WidgetId, WidgetState<any>>>(initialWidgetStates);
+    const [layouts, setLayouts] = useState<Layouts>(defaultLayouts);
+
     useEffect(() => {
-        setAskedQuestions(prev => {
-            const next = new Set<string>();
-            questionList.forEach(question => {
-                if (prev.has(question)) {
-                    next.add(question);
+        setWidgetStates(initialWidgetStates);
+        setLayouts(buildDefaultLayouts());
+    }, [initialWidgetStates]);
+
+    const updateWidgetData = useCallback(
+        (id: WidgetId, value: unknown) => {
+            setWidgetStates((prev) => {
+                const current = prev[id];
+                if (!current) {
+                    return prev;
                 }
-            });
-            return next;
-        });
-    }, [questionList]);
-
-    useEffect(() => {
-        if (!availableRoles.includes(activeRole)) {
-            setActiveRole(availableRoles[0] || 'default');
-        }
-    }, [availableRoles, activeRole]);
-
-    useEffect(() => {
-        if (!activeRole) {
-            return;
-        }
-        setStoryDeck(prev => {
-            if (prev.length === 0) {
-                return prev;
-            }
-            const needsRole = prev.some(item => !item.custom_notes[activeRole]);
-            return needsRole ? ensureRoleOnDeck(prev, activeRole) : prev;
-        });
-    }, [activeRole]);
-
-    const availableStories = useMemo(() => {
-        const selectedIds = new Set(storyDeck.map(item => item.story_id));
-        return (activeNarrative.impact_stories || []).filter(story => !selectedIds.has(story.story_id));
-    }, [storyDeck, activeNarrative]);
-
-    const toggleCoverage = (category: CoverageCategory, value: string) => {
-        setCovered(prev => {
-            const nextSet = new Set(prev[category]);
-            if (nextSet.has(value)) {
-                nextSet.delete(value);
-            } else {
-                nextSet.add(value);
-            }
-            return {
-                ...prev,
-                [category]: nextSet,
-            };
-        });
-    };
-
-    const resetCoverage = () => {
-        setCovered(createEmptyCoverageState());
-    };
-
-    const handleAddRole = () => {
-        const trimmed = newRoleName.trim();
-        if (!trimmed) {
-            return;
-        }
-        const existingRole = availableRoles.find(role => role.toLowerCase() === trimmed.toLowerCase());
-        if (existingRole) {
-            setActiveRole(existingRole);
-            setNewRoleName('');
-            return;
-        }
-        setStoryDeck(prev => ensureRoleOnDeck(prev, trimmed));
-        setActiveRole(trimmed);
-        setNewRoleName('');
-    };
-
-    const handleRemoveRole = (role: string) => {
-        if (role === 'default') {
-            return;
-        }
-        setStoryDeck(prev => removeRoleFromDeck(prev, role));
-    };
-
-    const handleNoteChange = (storyId: string, field: string, value: string) => {
-        setStoryDeck(prev => prev.map(item => {
-            if (item.story_id !== storyId) {
-                return item;
-            }
-            const roleNotes = item.custom_notes[activeRole] || {};
-            return {
-                ...item,
-                custom_notes: {
-                    ...item.custom_notes,
-                    [activeRole]: {
-                        ...roleNotes,
-                        [field]: value,
+                const timestamp = new Date().toISOString();
+                const nextState: Record<WidgetId, WidgetState<any>> = {
+                    ...prev,
+                    [id]: {
+                        ...current,
+                        data: value,
+                        lastUpdated: timestamp,
                     },
-                },
-            };
-        }));
-    };
+                };
 
-    const handleDragStart = (storyId: string) => {
-        setDraggingStoryId(storyId);
-    };
+                if (id === 'jobCheatSheet') {
+                    const cheatSheet = value as JobCheatSheetData;
+                    const checklist = prev.liveChecklist;
+                    if (checklist) {
+                        const updatedChecklist = {
+                            ...checklist,
+                            data: {
+                                ...checklist.data,
+                                metrics: cheatSheet.keySuccessMetrics,
+                                levers: cheatSheet.roleLevers,
+                                blockers: cheatSheet.potentialBlockers,
+                                covered: {
+                                    metrics: pruneCoverage(cheatSheet.keySuccessMetrics, checklist.data.covered.metrics),
+                                    levers: pruneCoverage(cheatSheet.roleLevers, checklist.data.covered.levers),
+                                    blockers: pruneCoverage(cheatSheet.potentialBlockers, checklist.data.covered.blockers),
+                                },
+                            },
+                            lastUpdated: timestamp,
+                        };
+                        nextState.liveChecklist = updatedChecklist;
+                    }
+                }
 
-    const handleDragEnter = (storyId: string) => {
-        if (!draggingStoryId || draggingStoryId === storyId) {
-            return;
-        }
-        setStoryDeck(prev => updateDeckOrder(prev, draggingStoryId, storyId));
-    };
+                return nextState;
+            });
+        },
+        [],
+    );
 
-    const handleDragEnd = () => {
-        setDraggingStoryId(null);
-    };
+    const toggleCollapse = useCallback(
+        (id: WidgetId) => {
+            const isCurrentlyCollapsed = Boolean(widgetStates[id]?.collapsed);
+            const nextCollapsed = !isCurrentlyCollapsed;
+            setWidgetStates((prev) => {
+                const current = prev[id];
+                if (!current) {
+                    return prev;
+                }
+                return {
+                    ...prev,
+                    [id]: {
+                        ...current,
+                        collapsed: nextCollapsed,
+                    },
+                };
+            });
+            setLayouts((prev) => {
+                const adjustHeight = (items: Layout[] | undefined, breakpoint: keyof Layouts) =>
+                    (items || []).map((item) => {
+                        if (item.i !== id) {
+                            return { ...item };
+                        }
+                        const defaultHeight = defaultHeights[breakpoint]?.[id] ?? item.h;
+                        return { ...item, h: nextCollapsed ? 2 : defaultHeight };
+                    });
+                return {
+                    lg: adjustHeight(prev.lg, 'lg'),
+                    md: adjustHeight(prev.md, 'md'),
+                    sm: adjustHeight(prev.sm, 'sm'),
+                };
+            });
+        },
+        [defaultHeights, widgetStates],
+    );
 
-    const handleAddStory = () => {
-        if (!storyToAdd) {
-            return;
-        }
-        const story = (activeNarrative.impact_stories || []).find(s => s.story_id === storyToAdd);
-        if (!story) {
-            return;
-        }
-        setStoryDeck(prev => upsertDeckStory(prev, story));
-        setStoryToAdd('');
-    };
+    const handleLayoutsChange = useCallback((_: Layout[], allLayouts: Layouts) => {
+        setLayouts(allLayouts);
+    }, []);
 
-    const handleRemoveStory = (storyId: string) => {
-        setStoryDeck(prev => prev
-            .filter(item => item.story_id !== storyId)
-            .map((item, index) => ({ ...item, order_index: index }))
-        );
-    };
+    const appendToNotes = useCallback(
+        (text: string) => {
+            setWidgetStates((prev) => {
+                const notes = prev.notes;
+                if (!notes) {
+                    return prev;
+                }
+                const nextContent = appendUnique(notes.data.content, text);
+                return {
+                    ...prev,
+                    notes: {
+                        ...notes,
+                        data: {
+                            ...notes.data,
+                            content: nextContent,
+                        },
+                        lastUpdated: new Date().toISOString(),
+                    },
+                };
+            });
+        },
+        [],
+    );
 
-    const updateRoleIntelligence = (
-        field: keyof NonNullable<InterviewPrepOutline['role_intelligence']>,
-        value: string,
-        isList: boolean = false,
-    ) => {
-        setPrepOutline(prev => {
-            const current = { ...(prev.role_intelligence || {}) } as Record<string, unknown>;
-            current[field as string] = isList ? sanitizeListInput(value) : value;
-            return {
-                ...prev,
-                role_intelligence: current as InterviewPrepOutline['role_intelligence'],
-            };
-        });
-    };
+    const widgetContext = useMemo<WidgetRuntimeContext>(
+        () => ({
+            appendToNotes,
+            jobAnalysis,
+            interview,
+            application,
+            narrative: activeNarrative,
+            availableStories: activeNarrative.impact_stories || [],
+        }),
+        [appendToNotes, jobAnalysis, interview, application, activeNarrative],
+    );
 
-    const updateJdInsights = (
-        field: keyof NonNullable<InterviewPrepOutline['jd_insights']>,
-        value: string,
-        isList: boolean = false,
-    ) => {
-        setPrepOutline(prev => {
-            const current = { ...(prev.jd_insights || {}) } as Record<string, unknown>;
-            current[field as string] = isList ? sanitizeListInput(value) : value;
-            return {
-                ...prev,
-                jd_insights: current as InterviewPrepOutline['jd_insights'],
-            };
-        });
-    };
-
-    const handleSave = async () => {
+    const handleSave = useCallback(async () => {
         setIsSaving(true);
         setSaveSuccess(false);
         try {
-            const payload: InterviewPayload = {
-                strategic_opening: editableOpening,
-                strategic_questions_to_ask: questionList,
-                story_deck: serializeDeck(storyDeck),
-                prep_outline: prepOutline,
+            const context = {
+                application,
+                interview,
+                narrative: activeNarrative,
+                prepOutline,
+                storyDeck,
+                jobAnalysis,
             };
+            const payload = componentRegistry.reduce<InterviewPayload>((acc, config) => {
+                const state = widgetStates[config.id];
+                if (state && config.serialize) {
+                    const partial = config.serialize(state, context);
+                    if (partial) {
+                        if (partial.prep_outline) {
+                            acc.prep_outline = {
+                                ...(acc.prep_outline || {}),
+                                ...partial.prep_outline,
+                            };
+                            delete partial.prep_outline;
+                        }
+                        Object.assign(acc, partial);
+                    }
+                }
+                return acc;
+            }, {} as InterviewPayload);
             await onSaveInterview(payload, interview.interview_id);
             setSaveSuccess(true);
             setTimeout(() => setSaveSuccess(false), 2000);
-        } catch (e) {
-            console.error("Failed to save Co-pilot data:", e);
+        } catch (error) {
+            console.error('Failed to save Interview Co-pilot data', error);
         } finally {
             setIsSaving(false);
         }
-    };
+    }, [
+        application,
+        interview,
+        activeNarrative,
+        prepOutline,
+        storyDeck,
+        jobAnalysis,
+        widgetStates,
+        onSaveInterview,
+    ]);
 
-    const handleSaveNotes = async () => {
+    const handleSaveNotes = useCallback(async () => {
+        const notesState = widgetStates.notes;
+        if (!notesState) {
+            return;
+        }
         setIsSavingNotes(true);
         setNotesSuccess(false);
         try {
-            await onSaveInterview({ live_notes: liveNotes }, interview.interview_id);
+            await onSaveInterview({ live_notes: notesState.data.content }, interview.interview_id);
             setNotesSuccess(true);
             setTimeout(() => setNotesSuccess(false), 2000);
-        } catch (e) {
-            console.error("Failed to save notes:", e);
+        } catch (error) {
+            console.error('Failed to save notes', error);
         } finally {
             setIsSavingNotes(false);
         }
-    };
-    const handleQuestionToggle = (question: string) => {
-        setAskedQuestions(prev => {
-            const newSet = new Set(prev);
-            if (newSet.has(question)) {
-                newSet.delete(question);
-            } else {
-                newSet.add(question);
-            }
-            return newSet;
-        });
-    };
+    }, [widgetStates, interview, onSaveInterview]);
 
-    const handleRerunAI = async () => {
+    const handleRerunAI = useCallback(async () => {
         setIsGeneratingPrep(true);
         try {
-            const isRecruiterScreen = interview.interview_type === "Step 6.1: Recruiter Screen";
+            const isRecruiterScreen = interview.interview_type === 'Step 6.1: Recruiter Screen';
             if (isRecruiterScreen) {
                 await onGenerateRecruiterScreenPrep(application, interview);
             } else {
                 await onGenerateInterviewPrep(application, interview);
             }
         } catch (error) {
-            console.error("Failed to rerun AI prep", error);
+            console.error('Failed to rerun AI prep', error);
         } finally {
             setIsGeneratingPrep(false);
         }
-    };
+    }, [application, interview, onGenerateInterviewPrep, onGenerateRecruiterScreenPrep]);
 
     const interviewer = interview.interview_contacts?.[0];
 
-    const coreProblem = jobAnalysis?.core_problem_analysis?.core_problem?.trim();
-    const keyMetrics = jobAnalysis?.key_success_metrics || [];
-    const roleLevers = jobAnalysis?.role_levers || [];
-    const potentialBlockers = jobAnalysis?.potential_blockers || [];
-    const roleTags = jobAnalysis?.tags || [];
-
-    useEffect(() => {
-        setCovered(createEmptyCoverageState());
-    }, [interview.interview_id, jobAnalysis]);
-
-    useEffect(() => {
-        setCovered(prev => pruneCoverageSelections(prev, keyMetrics, roleLevers, potentialBlockers));
-    }, [keyMetrics, roleLevers, potentialBlockers]);
-
-    const totalCoverageItems = keyMetrics.length + roleLevers.length + potentialBlockers.length;
-    const coveredCount = covered.metrics.size + covered.levers.size + covered.blockers.size;
-    const coveragePercent = totalCoverageItems === 0 ? 0 : Math.round((coveredCount / totalCoverageItems) * 100);
-
-    const handleQuickAdd = (text: string) => {
-        setLiveNotes(prev => appendUnique(prev, text));
-    };
-
     return (
-        <div className="fixed inset-0 z-50 bg-slate-900 bg-opacity-75 flex items-center justify-center p-4">
-            <div className="bg-slate-100 dark:bg-slate-900 rounded-xl shadow-2xl flex flex-col h-full w-full">
-                <header className="p-3 border-b border-slate-300 dark:border-slate-700 flex justify-between items-center flex-shrink-0">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/75 p-4">
+            <div className="flex h-full w-full flex-col rounded-xl bg-slate-100 shadow-2xl dark:bg-slate-900">
+                <header className="flex items-center justify-between border-b border-slate-300 p-3 dark:border-slate-700">
                     <div>
                         <h2 className="text-base font-bold text-slate-900 dark:text-white">Interview Co-pilot</h2>
-                        <p className="text-xs text-slate-500 dark:text-slate-400">{application.job_title} at {company.company_name}</p>
+                        <p className="text-xs text-slate-500 dark:text-slate-400">
+                            {application.job_title} at {company.company_name}
+                        </p>
+                        {interviewer && (
+                            <p className="text-[11px] text-slate-500 dark:text-slate-400">
+                                Interviewing with {interviewer.first_name} {interviewer.last_name}
+                            </p>
+                        )}
                     </div>
                     <div className="flex items-center gap-4">
                         <div className="flex items-center space-x-2">
-                             <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Live Mode</span>
-                            <Switch enabled={isEditMode} onChange={setIsEditMode} />
+                            <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Live Mode</span>
+                            <Switch enabled={mode === 'prep'} onChange={(value) => setMode(value ? 'prep' : 'live')} />
                             <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Prep Mode</span>
                         </div>
-                        {isEditMode ? (
-                            <button onClick={handleSave} disabled={isSaving} className={`px-3 py-1.5 text-xs font-semibold rounded-md shadow-sm transition-colors ${saveSuccess ? 'bg-green-600 text-white' : 'bg-blue-600 hover:bg-blue-700 text-white disabled:bg-blue-400'}`}>
-                                {isSaving ? 'Saving...' : saveSuccess ? 'Saved!' : 'Save Changes'}
+                        {mode === 'prep' ? (
+                            <button
+                                onClick={handleSave}
+                                disabled={isSaving}
+                                className={`rounded-md px-3 py-1.5 text-xs font-semibold shadow-sm transition-colors ${
+                                    saveSuccess
+                                        ? 'bg-green-600 text-white'
+                                        : 'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-400'
+                                }`}
+                            >
+                                {isSaving ? 'Saving…' : saveSuccess ? 'Saved!' : 'Save Changes'}
                             </button>
                         ) : (
-                             <button onClick={handleRerunAI} disabled={isGeneratingPrep} className="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-semibold rounded-md shadow-sm transition-colors bg-indigo-600 hover:bg-indigo-700 text-white disabled:bg-indigo-400">
-                                {isGeneratingPrep ? <LoadingSpinner/> : <SparklesIcon className="h-4 w-4"/>}
-                                Rerun AI Prep
-                            </button>
+                            <div className="flex items-center gap-2">
+                                <button
+                                    onClick={handleRerunAI}
+                                    disabled={isGeneratingPrep}
+                                    className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-indigo-700 disabled:bg-indigo-400"
+                                >
+                                    {isGeneratingPrep ? <LoadingSpinner /> : <SparklesIcon className="h-4 w-4" />}
+                                    Rerun AI Prep
+                                </button>
+                                <button
+                                    onClick={handleSaveNotes}
+                                    disabled={isSavingNotes}
+                                    className={`inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-semibold shadow-sm transition-colors ${
+                                        notesSuccess
+                                            ? 'bg-green-600 text-white'
+                                            : 'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-400'
+                                    }`}
+                                >
+                                    {isSavingNotes ? (
+                                        <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                                    ) : notesSuccess ? (
+                                        <CheckIcon className="h-4 w-4" />
+                                    ) : (
+                                        'Save Notes'
+                                    )}
+                                </button>
+                            </div>
                         )}
-                        <button onClick={onBack} className="text-xs font-semibold text-blue-600 dark:text-blue-400 hover:underline">
+                        <button
+                            onClick={onBack}
+                            className="text-xs font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                        >
                             Close
                         </button>
                     </div>
                 </header>
 
                 <main className="flex-1 overflow-hidden p-3">
-                    {isEditMode ? (
-                        <PrepWorkspace
-                            interview={interview}
-                            jobAnalysis={jobAnalysis}
-                            activeRole={activeRole}
-                            availableRoles={availableRoles}
-                            onRoleChange={setActiveRole}
-                            onAddRole={handleAddRole}
-                            onRemoveRole={handleRemoveRole}
-                            newRoleName={newRoleName}
-                            onNewRoleNameChange={setNewRoleName}
-                            availableStories={availableStories}
-                            storyToAdd={storyToAdd}
-                            onStoryToAddChange={setStoryToAdd}
-                            onAddStory={handleAddStory}
-                            storyDeck={storyDeck}
-                            onNoteChange={handleNoteChange}
-                            onDragStart={handleDragStart}
-                            onDragEnter={handleDragEnter}
-                            onDragEnd={handleDragEnd}
-                            onRemoveStory={handleRemoveStory}
-                            editableOpening={editableOpening}
-                            onChangeOpening={setEditableOpening}
-                            editableQuestions={editableQuestions}
-                            onChangeQuestions={setEditableQuestions}
-                            prepOutline={prepOutline}
-                            onUpdateRoleIntelligence={updateRoleIntelligence}
-                            onUpdateJdInsights={updateJdInsights}
-                        />
-                    ) : (
-                        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 h-full">
-                            <LiveRundown
-                                interview={interview}
-                                editableOpening={editableOpening}
-                                prepOutline={prepOutline}
-                                questionList={questionList}
-                                askedQuestions={askedQuestions}
-                                onToggleQuestion={handleQuestionToggle}
-                                storyDeck={storyDeck}
-                                activeRole={activeRole}
-                                availableRoles={availableRoles}
-                                onRoleChange={setActiveRole}
-                                jobAnalysis={jobAnalysis}
-                                onQuickAdd={handleQuickAdd}
-                                keyMetrics={keyMetrics}
-                                roleLevers={roleLevers}
-                                potentialBlockers={potentialBlockers}
-                                covered={covered}
-                                toggleCoverage={toggleCoverage}
-                                resetCoverage={resetCoverage}
-                                interviewer={interviewer}
-                                coveragePercent={coveragePercent}
-                                roleTags={roleTags}
-                            />
-                            <aside className="md:col-span-1 overflow-y-auto h-full flex flex-col">
-                                <CoPilotSection title="Live Notes" className="flex-grow flex flex-col">
-                                    <div className="flex items-center justify-between mb-2">
-                                        <p className="text-[11px] text-slate-500 dark:text-slate-400">Captured during the conversation</p>
-                                        <button
-                                            onClick={handleSaveNotes}
-                                            disabled={isSavingNotes}
-                                            className={`inline-flex items-center justify-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold shadow-sm transition-colors ${
-                                                notesSuccess ? 'bg-green-600 text-white' : 'bg-blue-600 hover:bg-blue-700 text-white disabled:bg-blue-400'
-                                            }`}
-                                        >
-                                            {isSavingNotes ? (
-                                                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                                            ) : notesSuccess ? (
-                                                <CheckIcon className="h-4 w-4" />
-                                            ) : (
-                                                'Save Notes'
+                    <ResponsiveGridLayout
+                        className="layout"
+                        layouts={layouts}
+                        cols={{ lg: 12, md: 8, sm: 1 }}
+                        breakpoints={{ lg: 1200, md: 996, sm: 480 }}
+                        rowHeight={32}
+                        margin={[12, 12]}
+                        onLayoutChange={handleLayoutsChange}
+                        draggableHandle=".widget-header"
+                    >
+                        {componentRegistry.map((config) => {
+                            const state = widgetStates[config.id];
+                            if (!state) {
+                                return null;
+                            }
+                            const editable = config.editableInModes ? config.editableInModes.includes(mode) : false;
+                            const isCollapsed = state.collapsed;
+                            const lastUpdated = state.lastUpdated;
+                            const titleTimestamp = lastUpdated ? formatTimestamp(lastUpdated) : undefined;
+                            const handleChange = (value: unknown) => updateWidgetData(config.id, value);
+                            const content = isCollapsed ? null : (
+                                <div className="flex-1 overflow-y-auto p-3">
+                                    <config.component
+                                        id={config.id}
+                                        mode={mode}
+                                        data={state.data}
+                                        onChange={handleChange}
+                                        lastUpdated={lastUpdated}
+                                        editable={editable}
+                                        context={widgetContext}
+                                    />
+                                </div>
+                            );
+                            return (
+                                <div key={config.id} className="flex h-full flex-col rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                                    <div className="widget-header flex items-center justify-between border-b border-slate-200 px-3 py-2 dark:border-slate-700">
+                                        <div>
+                                            <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-300">
+                                                {config.title}
+                                            </h3>
+                                            {titleTimestamp && (
+                                                <p className="text-[10px] text-slate-400 dark:text-slate-500">Updated {titleTimestamp}</p>
                                             )}
+                                        </div>
+                                        <button
+                                            type="button"
+                                            onClick={() => toggleCollapse(config.id)}
+                                            className="rounded-md border border-slate-300 px-2 py-1 text-[10px] font-semibold text-slate-600 hover:bg-slate-200 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+                                        >
+                                            {isCollapsed ? 'Expand' : 'Collapse'}
                                         </button>
                                     </div>
-                                    <textarea
-                                        value={liveNotes}
-                                        onChange={(e) => setLiveNotes(e.target.value)}
-                                        className="w-full flex-grow p-2 text-sm bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-700 rounded-md"
-                                        placeholder="Capture wins, fumbles, and new intelligence in real time…"
-                                    />
-                                </CoPilotSection>
-                            </aside>
-                        </div>
-                    )}
+                                    {content}
+                                </div>
+                            );
+                        })}
+                    </ResponsiveGridLayout>
                 </main>
             </div>
         </div>
     );
 };
+
+export default InterviewCopilotView;

--- a/components/interview-copilot/componentRegistry.tsx
+++ b/components/interview-copilot/componentRegistry.tsx
@@ -1,0 +1,254 @@
+import type { Layouts } from 'react-grid-layout';
+import { JobCheatSheetWidget } from './widgets/JobCheatSheetWidget';
+import { ClarifyingPromptWidget } from './widgets/ClarifyingPromptWidget';
+import { TopOfMindWidget } from './widgets/TopOfMindWidget';
+import { StrategicOpeningWidget } from './widgets/StrategicOpeningWidget';
+import { QuestionArsenalWidget } from './widgets/QuestionArsenalWidget';
+import { ImpactStoriesWidget } from './widgets/ImpactStoriesWidget';
+import { LiveChecklistWidget } from './widgets/LiveChecklistWidget';
+import { NotesWidget } from './widgets/NotesWidget';
+import type {
+    ClarifyingPromptData,
+    ImpactStoriesData,
+    JobCheatSheetData,
+    LiveChecklistData,
+    NotesData,
+    QuestionArsenalData,
+    StrategicOpeningData,
+    TopOfMindData,
+    WidgetConfig,
+    WidgetInitContext,
+    WidgetState,
+    WidgetId,
+} from './types';
+import { serializeDeck } from '../utils/interviewDeck';
+
+const createLayouts = (config: {
+    lg: { x: number; y: number; w: number; h: number };
+    md: { x: number; y: number; w: number; h: number };
+    sm: { x: number; y: number; w: number; h: number };
+    id: WidgetId;
+}): Layouts => ({
+    lg: [{ i: config.id, ...config.lg }],
+    md: [{ i: config.id, ...config.md }],
+    sm: [{ i: config.id, ...config.sm }],
+});
+
+const jobCheatSheetInitialState = ({ prepOutline }: WidgetInitContext): WidgetState<JobCheatSheetData> => ({
+    id: 'jobCheatSheet',
+    data: {
+        coreProblem: prepOutline.role_intelligence?.core_problem || '',
+        suggestedPositioning: prepOutline.role_intelligence?.suggested_positioning || '',
+        keySuccessMetrics: prepOutline.role_intelligence?.key_success_metrics || [],
+        roleLevers: prepOutline.role_intelligence?.role_levers || [],
+        potentialBlockers: prepOutline.role_intelligence?.potential_blockers || [],
+        businessContext: prepOutline.jd_insights?.business_context || '',
+        strategicImportance: prepOutline.jd_insights?.strategic_importance || '',
+        focusTags: prepOutline.jd_insights?.tags || [],
+    },
+});
+
+const clarifyInitialState = ({ prepOutline }: WidgetInitContext): WidgetState<ClarifyingPromptData> => {
+    const roleIntelligence = prepOutline.role_intelligence || {};
+    const lines = [
+        'To make sure I tailor my answers, could we clarify:',
+        roleIntelligence.core_problem ? `• Are we aligned that the core challenge is "${roleIntelligence.core_problem}"?` : null,
+        roleIntelligence.key_success_metrics?.length
+            ? `• Which success metrics matter most right now? (${roleIntelligence.key_success_metrics.join(', ')})`
+            : null,
+        roleIntelligence.role_levers?.length
+            ? `• Where do you need the most leverage today? (${roleIntelligence.role_levers.join(', ')})`
+            : null,
+        roleIntelligence.potential_blockers?.length
+            ? `• What blockers are slowing progress? (${roleIntelligence.potential_blockers.join(', ')})`
+            : null,
+    ].filter(Boolean);
+    return {
+        id: 'clarifyingPrompt',
+        data: { prompt: lines.join('\n') },
+    };
+};
+
+const topOfMindInitialState = ({ interview }: WidgetInitContext): WidgetState<TopOfMindData> => ({
+    id: 'topOfMind',
+    data: {
+        interviewerName: interview.interview_contacts?.[0]
+            ? `${interview.interview_contacts[0].first_name} ${interview.interview_contacts[0].last_name}`
+            : undefined,
+        interviewFormat: interview.interview_type,
+    },
+});
+
+const openingInitialState = ({ interview, narrative, application }: WidgetInitContext): WidgetState<StrategicOpeningData> => ({
+    id: 'strategicOpening',
+    data: {
+        opening:
+            interview.strategic_opening ||
+            `"I'm a product leader who excels at ${narrative.positioning_statement}. My understanding is the core challenge here is ${
+                application.job_problem_analysis_result?.core_problem_analysis?.core_problem || '...'
+            }. That's a problem I'm familiar with from my time when I ${narrative.impact_story_title}."`,
+    },
+});
+
+const questionsInitialState = ({ interview }: WidgetInitContext): WidgetState<QuestionArsenalData> => ({
+    id: 'questionArsenal',
+    data: {
+        questions: interview.strategic_questions_to_ask || [],
+        asked: [],
+    },
+});
+
+const storiesInitialState = ({ storyDeck }: WidgetInitContext): WidgetState<ImpactStoriesData> => ({
+    id: 'impactStories',
+    data: {
+        storyDeck,
+        activeRole: 'default',
+        newRoleName: '',
+        storyToAdd: '',
+    },
+});
+
+const checklistInitialState = ({ prepOutline }: WidgetInitContext): WidgetState<LiveChecklistData> => ({
+    id: 'liveChecklist',
+    data: {
+        metrics: prepOutline.role_intelligence?.key_success_metrics || [],
+        levers: prepOutline.role_intelligence?.role_levers || [],
+        blockers: prepOutline.role_intelligence?.potential_blockers || [],
+        covered: { metrics: [], levers: [], blockers: [] },
+    },
+});
+
+const notesInitialState = ({ interview }: WidgetInitContext): WidgetState<NotesData> => ({
+    id: 'notes',
+    data: {
+        content: interview.live_notes || '',
+    },
+});
+
+export const componentRegistry: WidgetConfig<any>[] = [
+    {
+        id: 'jobCheatSheet',
+        title: 'Job Cheat Sheet',
+        component: JobCheatSheetWidget,
+        defaultLayouts: createLayouts({
+            id: 'jobCheatSheet',
+            lg: { x: 0, y: 0, w: 6, h: 8 },
+            md: { x: 0, y: 0, w: 4, h: 8 },
+            sm: { x: 0, y: 0, w: 1, h: 8 },
+        }),
+        editableInModes: ['prep'],
+        getInitialState: jobCheatSheetInitialState,
+        serialize: ({ data }) => ({
+            prep_outline: {
+                role_intelligence: {
+                    core_problem: data.coreProblem,
+                    suggested_positioning: data.suggestedPositioning,
+                    key_success_metrics: data.keySuccessMetrics,
+                    role_levers: data.roleLevers,
+                    potential_blockers: data.potentialBlockers,
+                },
+                jd_insights: {
+                    business_context: data.businessContext,
+                    strategic_importance: data.strategicImportance,
+                    tags: data.focusTags,
+                },
+            },
+        }),
+    },
+    {
+        id: 'clarifyingPrompt',
+        title: 'Clarifying Prompt Launcher',
+        component: ClarifyingPromptWidget,
+        defaultLayouts: createLayouts({
+            id: 'clarifyingPrompt',
+            lg: { x: 6, y: 0, w: 3, h: 6 },
+            md: { x: 4, y: 0, w: 4, h: 6 },
+            sm: { x: 0, y: 8, w: 1, h: 6 },
+        }),
+        editableInModes: ['prep'],
+        getInitialState: clarifyInitialState,
+    },
+    {
+        id: 'topOfMind',
+        title: 'Top of Mind',
+        component: TopOfMindWidget,
+        defaultLayouts: createLayouts({
+            id: 'topOfMind',
+            lg: { x: 9, y: 0, w: 3, h: 3 },
+            md: { x: 4, y: 6, w: 4, h: 3 },
+            sm: { x: 0, y: 14, w: 1, h: 3 },
+        }),
+        editableInModes: ['prep'],
+        getInitialState: topOfMindInitialState,
+    },
+    {
+        id: 'strategicOpening',
+        title: 'Strategic Opening',
+        component: StrategicOpeningWidget,
+        defaultLayouts: createLayouts({
+            id: 'strategicOpening',
+            lg: { x: 6, y: 6, w: 6, h: 6 },
+            md: { x: 0, y: 8, w: 4, h: 6 },
+            sm: { x: 0, y: 17, w: 1, h: 6 },
+        }),
+        editableInModes: ['prep'],
+        getInitialState: openingInitialState,
+        serialize: ({ data }) => ({ strategic_opening: data.opening }),
+    },
+    {
+        id: 'questionArsenal',
+        title: 'Question Arsenal',
+        component: QuestionArsenalWidget,
+        defaultLayouts: createLayouts({
+            id: 'questionArsenal',
+            lg: { x: 0, y: 8, w: 6, h: 7 },
+            md: { x: 0, y: 14, w: 4, h: 7 },
+            sm: { x: 0, y: 23, w: 1, h: 7 },
+        }),
+        editableInModes: ['prep'],
+        getInitialState: questionsInitialState,
+        serialize: ({ data }) => ({ strategic_questions_to_ask: data.questions }),
+    },
+    {
+        id: 'impactStories',
+        title: 'Impact Stories',
+        component: ImpactStoriesWidget,
+        defaultLayouts: createLayouts({
+            id: 'impactStories',
+            lg: { x: 6, y: 12, w: 6, h: 12 },
+            md: { x: 4, y: 11, w: 4, h: 12 },
+            sm: { x: 0, y: 30, w: 1, h: 12 },
+        }),
+        editableInModes: ['prep'],
+        getInitialState: storiesInitialState,
+        serialize: ({ data }) => ({ story_deck: serializeDeck(data.storyDeck) }),
+    },
+    {
+        id: 'liveChecklist',
+        title: 'Live Checklist',
+        component: LiveChecklistWidget,
+        defaultLayouts: createLayouts({
+            id: 'liveChecklist',
+            lg: { x: 0, y: 15, w: 6, h: 8 },
+            md: { x: 0, y: 21, w: 4, h: 8 },
+            sm: { x: 0, y: 42, w: 1, h: 8 },
+        }),
+        getInitialState: checklistInitialState,
+    },
+    {
+        id: 'notes',
+        title: 'Live Notes',
+        component: NotesWidget,
+        defaultLayouts: createLayouts({
+            id: 'notes',
+            lg: { x: 0, y: 23, w: 12, h: 10 },
+            md: { x: 0, y: 29, w: 8, h: 10 },
+            sm: { x: 0, y: 50, w: 1, h: 10 },
+        }),
+        editableInModes: ['live'],
+        getInitialState: notesInitialState,
+        serialize: ({ data }) => ({ live_notes: data.content }),
+    },
+];
+
+export const widgetMap = new Map(componentRegistry.map((config) => [config.id, config]));

--- a/components/interview-copilot/shims/react-grid-layout.tsx
+++ b/components/interview-copilot/shims/react-grid-layout.tsx
@@ -1,0 +1,488 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type Breakpoint = 'lg' | 'md' | 'sm';
+
+export interface LayoutItem {
+    i: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    minW?: number;
+    maxW?: number;
+    minH?: number;
+    maxH?: number;
+    static?: boolean;
+}
+
+export type Layout = LayoutItem;
+
+export type Layouts = Partial<Record<Breakpoint, Layout[]>>;
+
+type Margin = [number, number];
+
+type Padding = [number, number];
+
+type BreakpointCols = Record<Breakpoint, number>;
+
+type BreakpointValues = Record<Breakpoint, number>;
+
+interface ResponsiveProps {
+    className?: string;
+    layouts: Layouts;
+    cols: BreakpointCols;
+    breakpoints: BreakpointValues;
+    rowHeight: number;
+    margin?: Margin;
+    containerPadding?: Padding;
+    draggableHandle?: string;
+    isDraggable?: boolean;
+    isResizable?: boolean;
+    onLayoutChange?: (currentLayout: Layout[], allLayouts: Layouts) => void;
+    onBreakpointChange?: (breakpoint: Breakpoint, cols: number) => void;
+    children: React.ReactNode;
+    width?: number;
+}
+
+interface DragState {
+    id: string;
+    originX: number;
+    originY: number;
+    startClientX: number;
+    startClientY: number;
+}
+
+interface ResizeState {
+    id: string;
+    originW: number;
+    originH: number;
+    startClientX: number;
+    startClientY: number;
+}
+
+const DEFAULT_MARGIN: Margin = [16, 16];
+const DEFAULT_PADDING: Padding = [0, 0];
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const rectsOverlap = (a: LayoutItem, b: LayoutItem) => {
+    if (a.i === b.i) {
+        return false;
+    }
+    return (
+        a.x < b.x + b.w &&
+        a.x + a.w > b.x &&
+        a.y < b.y + b.h &&
+        a.y + a.h > b.y
+    );
+};
+
+const resolveCollisions = (items: LayoutItem[], movingId: string): LayoutItem[] => {
+    const adjusted = items.map((item) => ({ ...item }));
+    const movingIndex = adjusted.findIndex((item) => item.i === movingId);
+    if (movingIndex === -1) {
+        return adjusted;
+    }
+    const moving = adjusted[movingIndex];
+
+    let collisions = true;
+    while (collisions) {
+        collisions = false;
+        for (const item of adjusted) {
+            if (item.i === movingId) {
+                continue;
+            }
+            if (rectsOverlap(moving, item)) {
+                item.y = moving.y + moving.h;
+                collisions = true;
+            }
+        }
+    }
+
+    return adjusted;
+};
+
+const sortedBreakpoints = (values: BreakpointValues) =>
+    (Object.entries(values) as [Breakpoint, number][]).sort((a, b) => a[1] - b[1]);
+
+const findBreakpoint = (width: number, values: BreakpointValues, fallback: Breakpoint): Breakpoint => {
+    const sorted = sortedBreakpoints(values);
+    let current: Breakpoint = fallback;
+    for (const [key, value] of sorted) {
+        if (width >= value) {
+            current = key;
+        }
+    }
+    return current;
+};
+
+const useStableCallback = <T extends (...args: any[]) => void>(callback?: T): T => {
+    const ref = useRef<T | undefined>(callback);
+    useEffect(() => {
+        ref.current = callback;
+    }, [callback]);
+    return useCallback(((...args: Parameters<T>) => {
+        ref.current?.(...args);
+    }) as T, []);
+};
+
+const useLatestRef = <T,>(value: T) => {
+    const ref = useRef(value);
+    useEffect(() => {
+        ref.current = value;
+    }, [value]);
+    return ref;
+};
+
+const getChildForKey = (children: React.ReactNode[], key: string) => {
+    for (const child of children) {
+        if (React.isValidElement(child) && child.key === key) {
+            return child;
+        }
+    }
+    return null;
+};
+
+const computePosition = (
+    item: LayoutItem,
+    cols: number,
+    width: number,
+    rowHeight: number,
+    margin: Margin,
+    padding: Padding,
+) => {
+    const [marginX, marginY] = margin;
+    const [paddingX, paddingY] = padding;
+    const effectiveWidth = Math.max(width - paddingX * 2, 0);
+    const colWidth = cols > 0 ? (effectiveWidth - marginX * (cols - 1)) / cols : width;
+    const unitX = colWidth + marginX;
+    const unitY = rowHeight + marginY;
+    const itemWidth = colWidth * item.w + marginX * Math.max(item.w - 1, 0);
+    const itemHeight = rowHeight * item.h + marginY * Math.max(item.h - 1, 0);
+    const left = paddingX + item.x * unitX;
+    const top = paddingY + item.y * unitY;
+    return { width: itemWidth, height: itemHeight, left, top };
+};
+
+const ResponsiveComponent: React.FC<ResponsiveProps> = ({
+    className,
+    layouts,
+    cols,
+    breakpoints,
+    rowHeight,
+    margin = DEFAULT_MARGIN,
+    containerPadding = DEFAULT_PADDING,
+    draggableHandle,
+    isDraggable = true,
+    isResizable = true,
+    onLayoutChange,
+    onBreakpointChange,
+    children,
+    width = 0,
+}) => {
+    const childrenArray = useMemo(() => React.Children.toArray(children), [children]);
+    const layoutRef = useLatestRef(layouts);
+    const colsRef = useLatestRef(cols);
+    const breakpointsRef = useLatestRef(breakpoints);
+    const dragState = useRef<DragState | null>(null);
+    const resizeState = useRef<ResizeState | null>(null);
+    const [activeBreakpoint, setActiveBreakpoint] = useState<Breakpoint>('lg');
+    const containerRef = useRef<HTMLDivElement | null>(null);
+
+    const emitLayoutChange = useStableCallback(onLayoutChange);
+    const emitBreakpointChange = useStableCallback(onBreakpointChange);
+
+    useEffect(() => {
+        const bp = findBreakpoint(width, breakpointsRef.current, 'sm');
+        setActiveBreakpoint((current) => {
+            if (current !== bp) {
+                emitBreakpointChange(bp, colsRef.current[bp]);
+            }
+            return bp;
+        });
+    }, [width, emitBreakpointChange, breakpointsRef, colsRef]);
+
+    const currentLayout = useMemo(() => layoutRef.current[activeBreakpoint] || [], [layoutRef, activeBreakpoint]);
+    const currentCols = colsRef.current[activeBreakpoint] || 1;
+
+    const handlePointerMove = useCallback(
+        (event: PointerEvent) => {
+            const dragging = dragState.current;
+            const resizing = resizeState.current;
+            if (!dragging && !resizing) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+
+            const layout = layoutRef.current[activeBreakpoint] || [];
+            const currentColsCount = colsRef.current[activeBreakpoint] || 1;
+            const container = containerRef.current;
+            if (!container) {
+                return;
+            }
+            const [marginX, marginY] = margin;
+            const [paddingX, paddingY] = containerPadding;
+            const effectiveWidth = Math.max(width - paddingX * 2, 0);
+            const colWidth = currentColsCount > 0 ? (effectiveWidth - marginX * (currentColsCount - 1)) / currentColsCount : width;
+            const unitX = colWidth + marginX;
+            const unitY = rowHeight + marginY;
+
+            if (dragging) {
+                const target = layout.find((item) => item.i === dragging.id);
+                if (!target || target.static) {
+                    return;
+                }
+                const deltaX = event.clientX - dragging.startClientX;
+                const deltaY = event.clientY - dragging.startClientY;
+                const movedX = Math.round(deltaX / unitX);
+                const movedY = Math.round(deltaY / unitY);
+                const nextX = clamp(dragging.originX + movedX, 0, Math.max(currentColsCount - target.w, 0));
+                const nextY = Math.max(dragging.originY + movedY, 0);
+                if (nextX === target.x && nextY === target.y) {
+                    return;
+                }
+                const updated = layout.map((item) =>
+                    item.i === target.i
+                        ? { ...item, x: nextX, y: nextY }
+                        : { ...item },
+                );
+                const resolved = resolveCollisions(updated, target.i);
+                const allLayouts = { ...layoutRef.current, [activeBreakpoint]: resolved };
+                emitLayoutChange(resolved, allLayouts);
+            } else if (resizing) {
+                const target = layout.find((item) => item.i === resizing.id);
+                if (!target || target.static) {
+                    return;
+                }
+                const deltaX = event.clientX - resizing.startClientX;
+                const deltaY = event.clientY - resizing.startClientY;
+                const deltaCols = Math.round(deltaX / unitX);
+                const deltaRows = Math.round(deltaY / unitY);
+                const minW = target.minW ?? 1;
+                const minH = target.minH ?? 1;
+                const maxW = target.maxW ?? currentColsCount;
+                const nextW = clamp(resizing.originW + deltaCols, minW, Math.min(maxW, currentColsCount - target.x));
+                const nextH = Math.max(resizing.originH + deltaRows, minH);
+                if (nextW === target.w && nextH === target.h) {
+                    return;
+                }
+                const updated = layout.map((item) =>
+                    item.i === target.i
+                        ? { ...item, w: nextW, h: nextH }
+                        : { ...item },
+                );
+                const resolved = resolveCollisions(updated, target.i);
+                const allLayouts = { ...layoutRef.current, [activeBreakpoint]: resolved };
+                emitLayoutChange(resolved, allLayouts);
+            }
+        },
+        [activeBreakpoint, colsRef, emitLayoutChange, layoutRef, margin, containerPadding, rowHeight, width],
+    );
+
+    const endInteractions = useCallback(() => {
+        dragState.current = null;
+        resizeState.current = null;
+        if (typeof window !== 'undefined') {
+            window.removeEventListener('pointermove', handlePointerMove);
+            window.removeEventListener('pointerup', endInteractions);
+            window.removeEventListener('pointercancel', endInteractions);
+        }
+    }, [handlePointerMove]);
+
+    const startDrag = useCallback(
+        (id: string, event: React.PointerEvent<HTMLDivElement>) => {
+            if (!isDraggable) {
+                return;
+            }
+            if (draggableHandle) {
+                const target = event.target as Element;
+                if (!target.closest(draggableHandle)) {
+                    return;
+                }
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            const layout = layoutRef.current[activeBreakpoint] || [];
+            const item = layout.find((entry) => entry.i === id);
+            if (!item || item.static) {
+                return;
+            }
+            dragState.current = {
+                id,
+                originX: item.x,
+                originY: item.y,
+                startClientX: event.clientX,
+                startClientY: event.clientY,
+            };
+            if (typeof window !== 'undefined') {
+                window.addEventListener('pointermove', handlePointerMove);
+                window.addEventListener('pointerup', endInteractions, { once: true });
+                window.addEventListener('pointercancel', endInteractions, { once: true });
+            }
+        },
+        [activeBreakpoint, draggableHandle, endInteractions, handlePointerMove, isDraggable, layoutRef],
+    );
+
+    const startResize = useCallback(
+        (id: string, event: React.PointerEvent<HTMLDivElement>) => {
+            if (!isResizable) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            const layout = layoutRef.current[activeBreakpoint] || [];
+            const item = layout.find((entry) => entry.i === id);
+            if (!item || item.static) {
+                return;
+            }
+            resizeState.current = {
+                id,
+                originW: item.w,
+                originH: item.h,
+                startClientX: event.clientX,
+                startClientY: event.clientY,
+            };
+            if (typeof window !== 'undefined') {
+                window.addEventListener('pointermove', handlePointerMove);
+                window.addEventListener('pointerup', endInteractions, { once: true });
+                window.addEventListener('pointercancel', endInteractions, { once: true });
+            }
+        },
+        [activeBreakpoint, endInteractions, handlePointerMove, isResizable, layoutRef],
+    );
+
+    useEffect(() => {
+        return () => {
+            if (typeof window !== 'undefined') {
+                window.removeEventListener('pointermove', handlePointerMove);
+                window.removeEventListener('pointerup', endInteractions);
+                window.removeEventListener('pointercancel', endInteractions);
+            }
+        };
+    }, [handlePointerMove, endInteractions]);
+
+    const positionedChildren = useMemo(() => {
+        return currentLayout.map((item) => {
+            const child = getChildForKey(childrenArray, item.i);
+            if (!child) {
+                return null;
+            }
+            const { width: itemWidth, height: itemHeight, left, top } = computePosition(
+                item,
+                currentCols,
+                width,
+                rowHeight,
+                margin,
+                containerPadding,
+            );
+            return (
+                <div
+                    key={item.i}
+                    className="rgl-item"
+                    style={{
+                        position: 'absolute',
+                        left,
+                        top,
+                        width: itemWidth,
+                        height: itemHeight,
+                        transition: dragState.current || resizeState.current ? 'none' : 'transform 150ms ease, width 150ms ease, height 150ms ease',
+                    }}
+                    onPointerDown={(event) => startDrag(item.i, event)}
+                >
+                    {child}
+                    {isResizable && !item.static && (
+                        <div
+                            className="rgl-resize-handle"
+                            onPointerDown={(event) => startResize(item.i, event)}
+                            style={{
+                                position: 'absolute',
+                                right: 4,
+                                bottom: 4,
+                                width: 12,
+                                height: 12,
+                                cursor: 'nwse-resize',
+                                background: 'transparent',
+                                touchAction: 'none',
+                            }}
+                        />
+                    )}
+                </div>
+            );
+        });
+    }, [
+        childrenArray,
+        containerPadding,
+        currentCols,
+        currentLayout,
+        isResizable,
+        margin,
+        rowHeight,
+        startDrag,
+        startResize,
+        width,
+    ]);
+
+    const totalHeight = useMemo(() => {
+        if (currentLayout.length === 0) {
+            return 0;
+        }
+        const maxItem = currentLayout.reduce((acc, item) => {
+            const bottom = item.y + item.h;
+            return bottom > acc ? bottom : acc;
+        }, 0);
+        const [marginX, marginY] = margin;
+        const [paddingX, paddingY] = containerPadding;
+        return (
+            paddingY * 2 +
+            maxItem * rowHeight +
+            Math.max(maxItem - 1, 0) * marginY
+        );
+    }, [containerPadding, currentLayout, margin, rowHeight]);
+
+    return (
+        <div ref={containerRef} className={className} style={{ position: 'relative', width: '100%', height: totalHeight }}>
+            {positionedChildren}
+        </div>
+    );
+};
+
+export const Responsive = ResponsiveComponent;
+
+export function WidthProvider<T extends React.ComponentType<any>>(Component: T) {
+    const WidthProviderComponent: React.FC<React.ComponentProps<T>> = (props) => {
+        const [width, setWidth] = useState(0);
+        const containerRef = useRef<HTMLDivElement | null>(null);
+
+        useEffect(() => {
+            const element = containerRef.current;
+            if (!element) {
+                return;
+            }
+            if (typeof ResizeObserver === 'undefined') {
+                setWidth(element.getBoundingClientRect().width);
+                return;
+            }
+            const observer = new ResizeObserver((entries) => {
+                for (const entry of entries) {
+                    setWidth(entry.contentRect.width);
+                }
+            });
+            observer.observe(element);
+            setWidth(element.getBoundingClientRect().width);
+            return () => observer.disconnect();
+        }, []);
+
+        return (
+            <div ref={containerRef} style={{ width: '100%' }}>
+                <Component {...(props as React.ComponentProps<T>)} width={width} />
+            </div>
+        );
+    };
+
+    WidthProviderComponent.displayName = `WidthProvider(${Component.displayName || Component.name || 'Component'})`;
+
+    return WidthProviderComponent as unknown as T;
+}
+
+export default ResponsiveComponent;

--- a/components/interview-copilot/types.ts
+++ b/components/interview-copilot/types.ts
@@ -1,0 +1,123 @@
+import type { Layouts } from 'react-grid-layout';
+import type {
+    ImpactStory,
+    Interview,
+    InterviewPrepOutline,
+    JobApplication,
+    JobProblemAnalysisResult,
+    StrategicNarrative,
+} from '../../types';
+import type { HydratedDeckItem } from '../../utils/interviewDeck';
+
+export type WidgetMode = 'prep' | 'live';
+
+export interface WidgetRuntimeContext {
+    appendToNotes?: (text: string) => void;
+    jobAnalysis?: JobProblemAnalysisResult | null;
+    interview: Interview;
+    application: JobApplication;
+    narrative: StrategicNarrative;
+    availableStories: ImpactStory[];
+}
+
+export interface WidgetProps<TData> {
+    id: string;
+    mode: WidgetMode;
+    data: TData;
+    onChange: (value: TData) => void;
+    lastUpdated?: string;
+    editable: boolean;
+    context: WidgetRuntimeContext;
+}
+
+export interface WidgetState<TData> {
+    id: string;
+    data: TData;
+    lastUpdated?: string;
+    collapsed?: boolean;
+}
+
+export interface WidgetConfig<TData> {
+    id: WidgetId;
+    title: string;
+    component: (props: WidgetProps<TData>) => JSX.Element;
+    defaultLayouts: Layouts;
+    editableInModes?: WidgetMode[];
+    allowCollapse?: boolean;
+    getInitialState: (context: WidgetInitContext) => WidgetState<TData>;
+    serialize?: (state: WidgetState<TData>, context: WidgetInitContext) => PartialWidgetPayload;
+}
+
+export interface WidgetInitContext {
+    application: JobApplication;
+    interview: Interview;
+    narrative: StrategicNarrative;
+    prepOutline: InterviewPrepOutline;
+    storyDeck: HydratedDeckItem[];
+    jobAnalysis?: JobProblemAnalysisResult | null;
+}
+
+export type PartialWidgetPayload = Partial<Pick<Interview, 'strategic_opening' | 'strategic_questions_to_ask' | 'live_notes' | 'prep_outline'>> & {
+    story_deck?: Interview['story_deck'];
+};
+
+export type WidgetId =
+    | 'jobCheatSheet'
+    | 'clarifyingPrompt'
+    | 'topOfMind'
+    | 'strategicOpening'
+    | 'questionArsenal'
+    | 'impactStories'
+    | 'liveChecklist'
+    | 'notes';
+
+export interface JobCheatSheetData {
+    coreProblem: string;
+    suggestedPositioning: string;
+    keySuccessMetrics: string[];
+    roleLevers: string[];
+    potentialBlockers: string[];
+    businessContext: string;
+    strategicImportance: string;
+    focusTags: string[];
+}
+
+export interface ClarifyingPromptData {
+    prompt: string;
+}
+
+export interface TopOfMindData {
+    interviewerName?: string;
+    interviewFormat: string;
+}
+
+export interface StrategicOpeningData {
+    opening: string;
+}
+
+export interface QuestionArsenalData {
+    questions: string[];
+    asked: string[];
+}
+
+export interface ImpactStoriesData {
+    storyDeck: HydratedDeckItem[];
+    activeRole: string;
+    newRoleName: string;
+    storyToAdd: string;
+}
+
+export interface LiveChecklistData {
+    metrics: string[];
+    levers: string[];
+    blockers: string[];
+    covered: {
+        metrics: string[];
+        levers: string[];
+        blockers: string[];
+    };
+}
+
+export interface NotesData {
+    content: string;
+}

--- a/components/interview-copilot/utils.ts
+++ b/components/interview-copilot/utils.ts
@@ -1,0 +1,32 @@
+export const appendUnique = (existing: string, addition: string): string => {
+    const trimmedAddition = addition.trim();
+    if (!trimmedAddition) {
+        return existing;
+    }
+    if (!existing.trim()) {
+        return trimmedAddition;
+    }
+    if (existing.includes(trimmedAddition)) {
+        return existing;
+    }
+    return `${existing.trimEnd()}\n\n${trimmedAddition}`;
+};
+
+export const linesToList = (value: string): string[] =>
+    value
+        .split('\n')
+        .map(item => item.trim())
+        .filter(Boolean);
+
+export const listToLines = (list: string[] = []): string => list.join('\n');
+
+export const formatTimestamp = (value?: string): string => {
+    if (!value) {
+        return 'Never';
+    }
+    try {
+        return new Date(value).toLocaleString();
+    } catch (error) {
+        return value;
+    }
+};

--- a/components/interview-copilot/widgets/ClarifyingPromptWidget.tsx
+++ b/components/interview-copilot/widgets/ClarifyingPromptWidget.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import type { WidgetProps } from '../types';
+import type { ClarifyingPromptData } from '../types';
+import { formatTimestamp } from '../utils';
+import { SparklesIcon } from '../../IconComponents';
+
+export const ClarifyingPromptWidget = ({
+    data,
+    onChange,
+    editable,
+    mode,
+    lastUpdated,
+    context,
+}: WidgetProps<ClarifyingPromptData>) => {
+    const handleSendToNotes = () => {
+        if (data.prompt && context.appendToNotes) {
+            context.appendToNotes(data.prompt);
+        }
+    };
+
+    if (!editable || mode === 'live') {
+        return (
+            <div className="space-y-3">
+                <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-xs font-mono text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200">
+                    {data.prompt || 'Draft clarifying prompts in prep mode to launch them quickly during the interview.'}
+                </div>
+                {data.prompt && (
+                    <button
+                        type="button"
+                        onClick={handleSendToNotes}
+                        className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-indigo-700"
+                    >
+                        <SparklesIcon className="h-4 w-4" />
+                        Send to Notes
+                    </button>
+                )}
+                <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            <textarea
+                value={data.prompt}
+                onChange={(event) => onChange({ ...data, prompt: event.target.value })}
+                rows={6}
+                className="w-full rounded-md border border-slate-300 bg-white p-3 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                placeholder="Draft clarifying prompts to keep at your fingertips during the conversation."
+            />
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+        </div>
+    );
+};
+
+export default ClarifyingPromptWidget;

--- a/components/interview-copilot/widgets/ImpactStoriesWidget.tsx
+++ b/components/interview-copilot/widgets/ImpactStoriesWidget.tsx
@@ -1,0 +1,332 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { WidgetProps } from '../types';
+import type { ImpactStoriesData } from '../types';
+import { formatTimestamp } from '../utils';
+import { ensureRoleOnDeck, removeRoleFromDeck, updateDeckOrder, upsertDeckStory } from '../../utils/interviewDeck';
+import type { HydratedDeckItem } from '../../utils/interviewDeck';
+import { GripVerticalIcon, SparklesIcon } from '../../IconComponents';
+
+const STORY_FORMAT_FIELDS: Record<string, string[]> = {
+    STAR: ['situation', 'task', 'action', 'result'],
+    SCOPE: ['situation', 'complication', 'opportunity', 'product_thinking', 'end_result'],
+    WINS: ['situation', 'what_i_did', 'impact', 'nuance'],
+    SPOTLIGHT: [
+        'situation',
+        'positive_moment_or_goal',
+        'observation_opportunity',
+        'task_action',
+        'learnings_leverage',
+        'impact_results',
+        'growth_grit',
+        'highlights_key_trait',
+        'takeaway_tie_in',
+    ],
+};
+
+const STORY_FORMAT_COLORS: Record<string, string> = {
+    STAR: 'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-300',
+    SCOPE: 'bg-purple-100 text-purple-800 dark:bg-purple-900/50 dark:text-purple-300',
+    WINS: 'bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300',
+    SPOTLIGHT: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/50 dark:text-yellow-300',
+};
+
+const readableLabel = (key: string) => key.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+
+const ImpactStoryTrigger = ({
+    item,
+    activeRole,
+    onNoteChange,
+    isPrep,
+}: {
+    item: HydratedDeckItem;
+    activeRole: string;
+    onNoteChange: (storyId: string, field: string, value: string) => void;
+    isPrep: boolean;
+}) => {
+    const story = item.story;
+    if (!story) {
+        return null;
+    }
+    const formatName = (story.format || 'STAR').toUpperCase();
+    const badgeColor = STORY_FORMAT_COLORS[formatName] || STORY_FORMAT_COLORS.STAR;
+    const orderedFields = STORY_FORMAT_FIELDS[formatName] || [];
+    const roleNotes = item.custom_notes[activeRole] || item.custom_notes.default || {};
+
+    return (
+        <div className="space-y-3 rounded-md border border-slate-300 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <div className="flex items-center justify-between gap-3">
+                <div>
+                    <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{story.story_title}</h4>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">{story.context_summary}</p>
+                </div>
+                <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase ${badgeColor}`}>{story.format}</span>
+            </div>
+            <div className="space-y-2">
+                {orderedFields.map((field) => {
+                    const label = readableLabel(field);
+                    const defaultValue = story.speaker_notes?.[field] || '';
+                    const value = roleNotes?.[field] ?? defaultValue;
+                    if (!isPrep && !value) {
+                        return null;
+                    }
+                    return (
+                        <div key={field}>
+                            <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</p>
+                            {isPrep ? (
+                                <textarea
+                                    value={value}
+                                    onChange={(event) => onNoteChange(item.story_id, field, event.target.value)}
+                                    rows={2}
+                                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-xs text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+                                />
+                            ) : (
+                                <p className="mt-1 whitespace-pre-wrap text-sm text-slate-700 dark:text-slate-200">{value || defaultValue}</p>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};
+
+export const ImpactStoriesWidget = ({
+    data,
+    onChange,
+    editable,
+    mode,
+    lastUpdated,
+    context,
+}: WidgetProps<ImpactStoriesData>) => {
+    const [draggingStoryId, setDraggingStoryId] = useState<string | null>(null);
+    const availableStories = context.availableStories || [];
+
+    const availableRoles = useMemo(() => {
+        const roles = new Set<string>(['default']);
+        data.storyDeck.forEach((item) => {
+            Object.keys(item.custom_notes).forEach((role) => roles.add(role));
+        });
+        return Array.from(roles);
+    }, [data.storyDeck]);
+
+    useEffect(() => {
+        if (!availableRoles.includes(data.activeRole)) {
+            onChange({ ...data, activeRole: availableRoles[0] || 'default' });
+        }
+    }, [availableRoles, data.activeRole, onChange, data]);
+
+    const handleRoleChange = (role: string) => {
+        const updatedDeck = ensureRoleOnDeck(data.storyDeck, role);
+        onChange({ ...data, activeRole: role, storyDeck: updatedDeck });
+    };
+
+    const handleAddRole = () => {
+        const trimmed = data.newRoleName.trim();
+        if (!trimmed || availableRoles.includes(trimmed)) {
+            return;
+        }
+        const updatedDeck = ensureRoleOnDeck(data.storyDeck, trimmed);
+        onChange({ ...data, activeRole: trimmed, newRoleName: '', storyDeck: updatedDeck });
+    };
+
+    const handleRemoveRole = (role: string) => {
+        if (role === 'default') {
+            return;
+        }
+        const updatedDeck = removeRoleFromDeck(data.storyDeck, role);
+        const remainingRoles = availableRoles.filter((value) => value !== role);
+        onChange({
+            ...data,
+            activeRole: remainingRoles[0] || 'default',
+            storyDeck: updatedDeck,
+        });
+    };
+
+    const handleNoteChange = (storyId: string, field: string, value: string) => {
+        const updatedDeck = data.storyDeck.map((item) => {
+            if (item.story_id !== storyId) {
+                return item;
+            }
+            const current = item.custom_notes[data.activeRole] || {};
+            return {
+                ...item,
+                custom_notes: {
+                    ...item.custom_notes,
+                    [data.activeRole]: {
+                        ...current,
+                        [field]: value,
+                    },
+                },
+            };
+        });
+        onChange({ ...data, storyDeck: updatedDeck });
+    };
+
+    const handleDragEnter = (storyId: string) => {
+        if (!draggingStoryId || draggingStoryId === storyId) {
+            return;
+        }
+        const updated = updateDeckOrder(data.storyDeck, draggingStoryId, storyId);
+        onChange({ ...data, storyDeck: updated });
+    };
+
+    const handleAddStory = () => {
+        const targetStory = availableStories.find((story) => story.story_id === data.storyToAdd);
+        if (!targetStory) {
+            return;
+        }
+        const updatedDeck = upsertDeckStory(data.storyDeck, targetStory);
+        onChange({ ...data, storyDeck: updatedDeck, storyToAdd: '' });
+    };
+
+    const handleRemoveStory = (storyId: string) => {
+        const updatedDeck = data.storyDeck.filter((item) => item.story_id !== storyId);
+        const reindexed = updatedDeck.map((item, index) => ({ ...item, order_index: index }));
+        onChange({ ...data, storyDeck: reindexed });
+    };
+
+    const liveView = (
+        <div className="space-y-3">
+            <div className="flex items-center gap-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Persona</span>
+                <select
+                    value={data.activeRole}
+                    onChange={(event) => handleRoleChange(event.target.value)}
+                    className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs dark:border-slate-600 dark:bg-slate-800"
+                >
+                    {availableRoles.map((role) => (
+                        <option key={role} value={role}>
+                            {role}
+                        </option>
+                    ))}
+                </select>
+            </div>
+            <div className="space-y-2">
+                {data.storyDeck.length > 0 ? (
+                    data.storyDeck.map((item) => (
+                        <ImpactStoryTrigger key={item.story_id} item={item} activeRole={data.activeRole} onNoteChange={handleNoteChange} isPrep={false} />
+                    ))
+                ) : (
+                    <p className="text-sm text-slate-500 dark:text-slate-400">Add stories in prep mode to surface them here.</p>
+                )}
+            </div>
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+        </div>
+    );
+
+    if (!editable || mode === 'live') {
+        return liveView;
+    }
+
+    const availableStoryOptions = availableStories.filter((story) => !data.storyDeck.some((item) => item.story_id === story.story_id));
+
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Persona</span>
+                    <select
+                        value={data.activeRole}
+                        onChange={(event) => handleRoleChange(event.target.value)}
+                        className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-800"
+                    >
+                        {availableRoles.map((role) => (
+                            <option key={role} value={role}>
+                                {role}
+                            </option>
+                        ))}
+                    </select>
+                    {data.activeRole !== 'default' && (
+                        <button
+                            type="button"
+                            onClick={() => handleRemoveRole(data.activeRole)}
+                            className="inline-flex items-center rounded-md border border-slate-300 px-2 py-1 text-[10px] font-semibold text-red-600 shadow-sm hover:bg-slate-200 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-red-500 dark:border-slate-600 dark:text-red-300 dark:hover:bg-slate-700"
+                        >
+                            Remove Role
+                        </button>
+                    )}
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                    <input
+                        type="text"
+                        value={data.newRoleName}
+                        onChange={(event) => onChange({ ...data, newRoleName: event.target.value })}
+                        placeholder="Add new persona"
+                        className="w-full max-w-xs rounded-md border border-slate-300 bg-white px-2 py-1 text-xs shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-800"
+                    />
+                    <button
+                        type="button"
+                        onClick={handleAddRole}
+                        className="inline-flex items-center rounded-md bg-indigo-600 px-2 py-1 text-[10px] font-semibold text-white shadow-sm hover:bg-indigo-700"
+                    >
+                        Add Persona
+                    </button>
+                </div>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <select
+                    value={data.storyToAdd}
+                    onChange={(event) => onChange({ ...data, storyToAdd: event.target.value })}
+                    className="w-full rounded-md border border-slate-300 bg-white px-2 py-1 text-xs shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-800"
+                >
+                    <option value="">Select story to add</option>
+                    {availableStoryOptions.map((story) => (
+                        <option key={story.story_id} value={story.story_id}>
+                            {story.story_title}
+                        </option>
+                    ))}
+                </select>
+                <button
+                    type="button"
+                    onClick={handleAddStory}
+                    disabled={!data.storyToAdd}
+                    className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-400"
+                >
+                    <SparklesIcon className="h-4 w-4" /> Add Story
+                </button>
+            </div>
+            <div className="space-y-3">
+                {data.storyDeck.length > 0 ? (
+                    data.storyDeck.map((item) => (
+                        <div
+                            key={item.story_id}
+                            className="cursor-grab rounded-md border border-dashed border-slate-300 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+                            draggable
+                            onDragStart={() => setDraggingStoryId(item.story_id)}
+                            onDragOver={(event) => {
+                                event.preventDefault();
+                                handleDragEnter(item.story_id);
+                            }}
+                            onDragEnd={() => setDraggingStoryId(null)}
+                        >
+                            <div className="flex items-center justify-between gap-2">
+                                <div className="flex items-center gap-2">
+                                    <GripVerticalIcon className="h-4 w-4 text-slate-400" />
+                                    <div>
+                                        <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">{item.story?.story_title || 'Untitled Story'}</p>
+                                        <p className="text-xs text-slate-500 dark:text-slate-400">{item.story?.context_summary}</p>
+                                    </div>
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={() => handleRemoveStory(item.story_id)}
+                                    className="rounded-md border border-slate-300 px-2 py-1 text-[10px] font-semibold text-red-600 hover:bg-slate-200 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-red-500 dark:border-slate-600 dark:text-red-300 dark:hover:bg-slate-700"
+                                >
+                                    Remove
+                                </button>
+                            </div>
+                            <div className="mt-3">
+                                <ImpactStoryTrigger item={item} activeRole={data.activeRole} onNoteChange={handleNoteChange} isPrep />
+                            </div>
+                        </div>
+                    ))
+                ) : (
+                    <p className="text-sm text-slate-500 dark:text-slate-400">Add stories from your narrative to craft tailored talking points.</p>
+                )}
+            </div>
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+        </div>
+    );
+};
+
+export default ImpactStoriesWidget;

--- a/components/interview-copilot/widgets/JobCheatSheetWidget.tsx
+++ b/components/interview-copilot/widgets/JobCheatSheetWidget.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import type { WidgetProps } from '../types';
+import { formatTimestamp, linesToList, listToLines } from '../utils';
+import type { JobCheatSheetData } from '../types';
+
+const SectionField = ({
+    label,
+    value,
+}: {
+    label: string;
+    value?: string | string[];
+}) => {
+    if (!value || (Array.isArray(value) && value.length === 0)) {
+        return null;
+    }
+    const rendered = Array.isArray(value) ? value.join(', ') : value;
+    if (!rendered) {
+        return null;
+    }
+    return (
+        <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</p>
+            <p className="mt-1 whitespace-pre-wrap text-sm text-slate-700 dark:text-slate-200">{rendered}</p>
+        </div>
+    );
+};
+
+export const JobCheatSheetWidget = ({
+    data,
+    onChange,
+    editable,
+    mode,
+    lastUpdated,
+}: WidgetProps<JobCheatSheetData>) => {
+    const handleUpdate = (field: keyof JobCheatSheetData, value: string, asList = false) => {
+        const next: JobCheatSheetData = {
+            ...data,
+            [field]: asList ? linesToList(value) : value,
+        } as JobCheatSheetData;
+        onChange(next);
+    };
+
+    if (!editable || mode === 'live') {
+        return (
+            <div className="space-y-3">
+                <SectionField label="Core Problem" value={data.coreProblem} />
+                <SectionField label="Suggested Positioning" value={data.suggestedPositioning} />
+                <SectionField label="Success Metrics" value={data.keySuccessMetrics} />
+                <SectionField label="Role Levers" value={data.roleLevers} />
+                <SectionField label="Potential Blockers" value={data.potentialBlockers} />
+                <SectionField label="Business Context" value={data.businessContext} />
+                <SectionField label="Strategic Importance" value={data.strategicImportance} />
+                <SectionField label="Focus Tags" value={data.focusTags} />
+                <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Core Problem</label>
+                <textarea
+                    value={data.coreProblem}
+                    onChange={(event) => handleUpdate('coreProblem', event.target.value)}
+                    rows={3}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                />
+            </div>
+            <div>
+                <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Suggested Positioning</label>
+                <textarea
+                    value={data.suggestedPositioning}
+                    onChange={(event) => handleUpdate('suggestedPositioning', event.target.value)}
+                    rows={3}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                />
+            </div>
+            <div>
+                <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Key Success Metrics</label>
+                <textarea
+                    value={listToLines(data.keySuccessMetrics)}
+                    onChange={(event) => handleUpdate('keySuccessMetrics', event.target.value, true)}
+                    rows={3}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-xs font-mono text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                    placeholder="One metric per line"
+                />
+            </div>
+            <div>
+                <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Role Levers</label>
+                <textarea
+                    value={listToLines(data.roleLevers)}
+                    onChange={(event) => handleUpdate('roleLevers', event.target.value, true)}
+                    rows={3}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-xs font-mono text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                    placeholder="One lever per line"
+                />
+            </div>
+            <div>
+                <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Potential Blockers</label>
+                <textarea
+                    value={listToLines(data.potentialBlockers)}
+                    onChange={(event) => handleUpdate('potentialBlockers', event.target.value, true)}
+                    rows={3}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-xs font-mono text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                    placeholder="One blocker per line"
+                />
+            </div>
+            <div>
+                <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Business Context</label>
+                <textarea
+                    value={data.businessContext}
+                    onChange={(event) => handleUpdate('businessContext', event.target.value)}
+                    rows={3}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                />
+            </div>
+            <div>
+                <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Strategic Importance</label>
+                <textarea
+                    value={data.strategicImportance}
+                    onChange={(event) => handleUpdate('strategicImportance', event.target.value)}
+                    rows={3}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                />
+            </div>
+            <div>
+                <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Focus Tags</label>
+                <textarea
+                    value={listToLines(data.focusTags)}
+                    onChange={(event) => handleUpdate('focusTags', event.target.value, true)}
+                    rows={3}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-xs font-mono text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                    placeholder="One tag per line"
+                />
+            </div>
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+        </div>
+    );
+};
+
+export default JobCheatSheetWidget;

--- a/components/interview-copilot/widgets/LiveChecklistWidget.tsx
+++ b/components/interview-copilot/widgets/LiveChecklistWidget.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import type { WidgetProps } from '../types';
+import type { LiveChecklistData } from '../types';
+import { formatTimestamp } from '../utils';
+import { CheckIcon } from '../../IconComponents';
+
+const ToggleList = ({
+    label,
+    items,
+    covered,
+    onToggle,
+}: {
+    label: string;
+    items: string[];
+    covered: string[];
+    onToggle: (item: string) => void;
+}) => (
+    <div>
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</h4>
+        <ul className="mt-1 space-y-1">
+            {items.map((item, index) => {
+                const isCovered = covered.includes(item);
+                return (
+                    <li key={`${label}-${index}`}>
+                        <button
+                            type="button"
+                            onClick={() => onToggle(item)}
+                            className={`flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm transition ${isCovered ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-200' : 'text-slate-700 hover:bg-slate-200 dark:text-slate-200 dark:hover:bg-slate-700/80'}`}
+                        >
+                            <span className={`flex h-4 w-4 items-center justify-center rounded border ${isCovered ? 'border-green-600 bg-green-600 text-white' : 'border-slate-400 text-transparent'}`}>
+                                <CheckIcon className="h-3 w-3" />
+                            </span>
+                            <span className={isCovered ? 'line-through' : ''}>{item}</span>
+                        </button>
+                    </li>
+                );
+            })}
+        </ul>
+    </div>
+);
+
+export const LiveChecklistWidget = ({
+    data,
+    onChange,
+    lastUpdated,
+}: WidgetProps<LiveChecklistData>) => {
+    const toggleItem = (category: keyof LiveChecklistData['covered'], value: string) => {
+        const existing = new Set(data.covered[category]);
+        if (existing.has(value)) {
+            existing.delete(value);
+        } else {
+            existing.add(value);
+        }
+        onChange({
+            ...data,
+            covered: {
+                ...data.covered,
+                [category]: Array.from(existing),
+            },
+        });
+    };
+
+    const totalItems = data.metrics.length + data.levers.length + data.blockers.length;
+    const completed = data.covered.metrics.length + data.covered.levers.length + data.covered.blockers.length;
+    const coveragePercent = totalItems === 0 ? 0 : Math.round((completed / totalItems) * 100);
+
+    return (
+        <div className="space-y-3">
+            <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">Coverage Progress</p>
+                <span className="text-xs text-slate-500 dark:text-slate-400">{coveragePercent}%</span>
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                <ToggleList
+                    label="Success Metrics"
+                    items={data.metrics}
+                    covered={data.covered.metrics}
+                    onToggle={(value) => toggleItem('metrics', value)}
+                />
+                <ToggleList
+                    label="Role Levers"
+                    items={data.levers}
+                    covered={data.covered.levers}
+                    onToggle={(value) => toggleItem('levers', value)}
+                />
+                <ToggleList
+                    label="Potential Blockers"
+                    items={data.blockers}
+                    covered={data.covered.blockers}
+                    onToggle={(value) => toggleItem('blockers', value)}
+                />
+            </div>
+            <button
+                type="button"
+                onClick={() =>
+                    onChange({
+                        ...data,
+                        covered: { metrics: [], levers: [], blockers: [] },
+                    })
+                }
+                className="inline-flex items-center rounded-md border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-600 shadow-sm hover:bg-slate-200 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+            >
+                Reset Coverage
+            </button>
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+        </div>
+    );
+};
+
+export default LiveChecklistWidget;

--- a/components/interview-copilot/widgets/NotesWidget.tsx
+++ b/components/interview-copilot/widgets/NotesWidget.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import type { WidgetProps } from '../types';
+import type { NotesData } from '../types';
+import { formatTimestamp } from '../utils';
+
+export const NotesWidget = ({
+    data,
+    onChange,
+    editable,
+    mode,
+    lastUpdated,
+}: WidgetProps<NotesData>) => {
+    if (!editable) {
+        return (
+            <div className="space-y-2">
+                <p className="text-sm text-slate-700 dark:text-slate-300 whitespace-pre-wrap">{data.content || 'Notes captured during the conversation will appear here.'}</p>
+                <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-2">
+            <textarea
+                value={data.content}
+                onChange={(event) => onChange({ ...data, content: event.target.value })}
+                rows={12}
+                className="w-full flex-grow rounded-md border border-slate-300 bg-white p-3 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                placeholder={mode === 'live' ? 'Capture wins, fumbles, and new intelligence in real time…' : 'Use this space to pre-draft notes or reminders.'}
+            />
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+        </div>
+    );
+};
+
+export default NotesWidget;

--- a/components/interview-copilot/widgets/QuestionArsenalWidget.tsx
+++ b/components/interview-copilot/widgets/QuestionArsenalWidget.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import type { WidgetProps } from '../types';
+import type { QuestionArsenalData } from '../types';
+import { formatTimestamp, listToLines, linesToList } from '../utils';
+
+export const QuestionArsenalWidget = ({
+    data,
+    onChange,
+    editable,
+    mode,
+    lastUpdated,
+}: WidgetProps<QuestionArsenalData>) => {
+    const toggleAsked = (question: string) => {
+        const asked = new Set(data.asked);
+        if (asked.has(question)) {
+            asked.delete(question);
+        } else {
+            asked.add(question);
+        }
+        onChange({ ...data, asked: Array.from(asked) });
+    };
+
+    if (mode === 'prep' && editable) {
+        return (
+            <div className="space-y-3">
+                <textarea
+                    value={listToLines(data.questions)}
+                    onChange={(event) => onChange({ ...data, questions: linesToList(event.target.value) })}
+                    rows={10}
+                    className="w-full rounded-md border border-slate-300 bg-white p-3 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                    placeholder="List strategic questions you plan to ask, one per line."
+                />
+                <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            {data.questions.length > 0 ? (
+                data.questions.map((question, index) => {
+                    const id = `${index}-${question}`;
+                    const isChecked = data.asked.includes(question);
+                    return (
+                        <label key={id} htmlFor={id} className="flex cursor-pointer items-start gap-2">
+                            <input
+                                id={id}
+                                type="checkbox"
+                                checked={isChecked}
+                                onChange={() => toggleAsked(question)}
+                                className="mt-1 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                            />
+                            <span className={`text-sm leading-6 text-slate-700 dark:text-slate-300 ${isChecked ? 'line-through text-slate-400 dark:text-slate-500' : ''}`}>
+                                {question}
+                            </span>
+                        </label>
+                    );
+                })
+            ) : (
+                <p className="text-sm text-slate-500 dark:text-slate-400">Add strategic questions in prep mode.</p>
+            )}
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+        </div>
+    );
+};
+
+export default QuestionArsenalWidget;

--- a/components/interview-copilot/widgets/StrategicOpeningWidget.tsx
+++ b/components/interview-copilot/widgets/StrategicOpeningWidget.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { WidgetProps } from '../types';
+import type { StrategicOpeningData } from '../types';
+import { formatTimestamp } from '../utils';
+
+export const StrategicOpeningWidget = ({
+    data,
+    onChange,
+    editable,
+    mode,
+    lastUpdated,
+}: WidgetProps<StrategicOpeningData>) => {
+    if (!editable || mode === 'live') {
+        return (
+            <div className="space-y-2">
+                <p className="text-sm italic text-slate-700 dark:text-slate-300 whitespace-pre-wrap">{data.opening}</p>
+                <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-2">
+            <textarea
+                value={data.opening}
+                onChange={(event) => onChange({ ...data, opening: event.target.value })}
+                rows={6}
+                className="w-full rounded-md border border-slate-300 bg-white p-3 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+            />
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+        </div>
+    );
+};
+
+export default StrategicOpeningWidget;

--- a/components/interview-copilot/widgets/TopOfMindWidget.tsx
+++ b/components/interview-copilot/widgets/TopOfMindWidget.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import type { WidgetProps } from '../types';
+import type { TopOfMindData } from '../types';
+import { formatTimestamp } from '../utils';
+
+export const TopOfMindWidget = ({
+    data,
+    onChange,
+    editable,
+    mode,
+    lastUpdated,
+}: WidgetProps<TopOfMindData>) => {
+    if (!editable || mode === 'live') {
+        return (
+            <div className="space-y-1 text-xs text-slate-600 dark:text-slate-300">
+                <p>
+                    <strong>Interviewing with:</strong> {data.interviewerName || 'TBD'}
+                </p>
+                <p>
+                    <strong>Format:</strong> {data.interviewFormat}
+                </p>
+                <p className="pt-2 text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            <div>
+                <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Interviewer</label>
+                <input
+                    type="text"
+                    value={data.interviewerName || ''}
+                    onChange={(event) => onChange({ ...data, interviewerName: event.target.value })}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                    placeholder="Name of the interviewer"
+                />
+            </div>
+            <div>
+                <label className="block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Format</label>
+                <input
+                    type="text"
+                    value={data.interviewFormat}
+                    onChange={(event) => onChange({ ...data, interviewFormat: event.target.value })}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white p-2 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                />
+            </div>
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
+        </div>
+    );
+};
+
+export default TopOfMindWidget;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "file-saver": "2.0.5",
     "html2canvas": "^1.4.1",
     "jspdf": "^3.0.2",
+    "react-grid-layout": "^1.4.4",
+    "react-resizable": "^3.0.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "6.23.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
     "paths": {
       "@/*": [
         "./*"
+      ],
+      "react-grid-layout": [
+        "./components/interview-copilot/shims/react-grid-layout"
       ]
     },
     "allowImportingTsExtensions": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,10 @@ export default defineConfig(({ mode }) => {
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),
+          'react-grid-layout': path.resolve(
+              __dirname,
+              'components/interview-copilot/shims/react-grid-layout.tsx',
+          ),
         }
       },
       test: {


### PR DESCRIPTION
## Summary
- add a shimmed `react-grid-layout` implementation that provides responsive dragging and resizing without relying on the external package
- wire the shim through Vite and TypeScript path aliases so existing copilot widgets resolve the module locally

## Testing
- `npm run build` *(fails: vite: not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eed12c96a08330b13d741ec3da62d1