### PR TITLE
Clarify alias usage in interview deck scripts

### DIFF
--- a/DB Scripts/sqitch/deploy/add_interview_copilot_columns.sql
+++ b/DB Scripts/sqitch/deploy/add_interview_copilot_columns.sql
@@ -198,6 +198,7 @@ AS $function$
             ),
             '[]'::jsonb
         ) AS interview_contacts
+    -- Source interviews for the given application; alias i is referenced above.
     FROM public.interviews i
     WHERE i.job_application_id = p_job_application_id
     ORDER BY i.interview_date NULLS LAST, i.created_at DESC;

--- a/DB Scripts/sqitch/revert/add_interview_copilot_columns.sql
+++ b/DB Scripts/sqitch/revert/add_interview_copilot_columns.sql
@@ -131,6 +131,7 @@ AS $function$
             ),
             '[]'::jsonb
         ) AS interview_contacts
+    -- Source interviews for the given application; alias i is referenced above.
     FROM public.interviews i
     WHERE i.job_application_id = p_job_application_id
     ORDER BY i.interview_date NULLS LAST, i.created_at DESC;


### PR DESCRIPTION
## Summary
- document the interview query's reliance on the `i` alias in both the deploy and revert scripts

## Testing
- sqitch deploy *(fails: `sqitch` not installed in container)*
- sqitch revert *(fails: `sqitch` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ef52c3a1948330a22d94154dd54f8b