### PR TITLE
Fix widget type definitions for interview co-pilot

### DIFF
--- a/components/interview-copilot/types.ts
+++ b/components/interview-copilot/types.ts
@@ -7,17 +7,7 @@ import type {
     JobProblemAnalysisResult,
     StrategicNarrative,
 } from '../../types';
-<<<<<<< HEAD
 import type { HydratedDeckItem } from '../../utils/interviewDeck';
->>>>>>> origin/New-Interview-Co-Pilot
-
-export type WidgetMode = 'prep' | 'live';
-import type { HydratedDeckItem } from '../../utils/interviewDeck';
-
-export type WidgetMode = 'prep' | 'live';
-=======
-import type { HydratedDeckItem } from '../../utils/interviewDeck';
->>>>>>> origin/New-Interview-Co-Pilot
 
 export type WidgetMode = 'prep' | 'live';
 
@@ -49,15 +39,6 @@ export interface WidgetState<TData> {
 
 export interface WidgetConfig<TData> {
     id: WidgetId;
->>>>>>> origin/New-Interview-Co-Pilot
-    title: string;
-export interface WidgetConfig<TData> {
-    id: WidgetId;
-    title: string;
-=======
-export interface WidgetConfig<TData> {
-    id: WidgetId;
->>>>>>> origin/New-Interview-Co-Pilot
     title: string;
     component: (props: WidgetProps<TData>) => JSX.Element;
     defaultLayouts: Layouts;
@@ -76,7 +57,9 @@ export interface WidgetInitContext {
     jobAnalysis?: JobProblemAnalysisResult | null;
 }
 
-export type PartialWidgetPayload = Partial<Pick<Interview, 'strategic_opening' | 'strategic_questions_to_ask' | 'live_notes' | 'prep_outline'>> & {
+export type PartialWidgetPayload = Partial<
+    Pick<Interview, 'strategic_opening' | 'strategic_questions_to_ask' | 'live_notes' | 'prep_outline'>
+> & {
     story_deck?: Interview['story_deck'];
 };
 
@@ -90,22 +73,6 @@ export type WidgetId =
     | 'liveChecklist'
     | 'notes';
 
-<<<<<<< HEAD
-export type WidgetDataMap = {
-    jobCheatSheet: JobCheatSheetData;
-    clarifyingPrompt: ClarifyingPromptData;
-    topOfMind: TopOfMindData;
-    strategicOpening: StrategicOpeningData;
-    questionArsenal: QuestionArsenalData;
-    impactStories: ImpactStoriesData;
-    liveChecklist: LiveChecklistData;
-    notes: NotesData;
-};
-
-export type WidgetStateMap = { [K in WidgetId]: WidgetState<WidgetDataMap[K]> };
-
-=======
->>>>>>> origin/New-Interview-Co-Pilot
 export interface JobCheatSheetData {
     coreProblem: string;
     suggestedPositioning: string;
@@ -156,3 +123,16 @@ export interface LiveChecklistData {
 export interface NotesData {
     content: string;
 }
+
+export type WidgetDataMap = {
+    jobCheatSheet: JobCheatSheetData;
+    clarifyingPrompt: ClarifyingPromptData;
+    topOfMind: TopOfMindData;
+    strategicOpening: StrategicOpeningData;
+    questionArsenal: QuestionArsenalData;
+    impactStories: ImpactStoriesData;
+    liveChecklist: LiveChecklistData;
+    notes: NotesData;
+};
+
+export type WidgetStateMap = { [K in WidgetId]: WidgetState<WidgetDataMap[K]> };


### PR DESCRIPTION
## Summary
- remove merge conflict markers from the interview co-pilot type definitions
- ensure widget mode, config, data, and state mappings align with the widget registry

## Testing
- npm run build *(fails: vite not found because dependencies are unavailable without installing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ef563840b08330a34c8633073e85ab