### PR TITLE
Handle missing Interview Copilot narrative gracefully

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1221,16 +1221,27 @@ const AppContent = () => {
             return { app: null, interview: null, company: null };
         }, [applications, interviewId, companies]);
     
-        if (isAppLoading || !app || !interview || !activeNarrative || !company) {
+        const fallbackNarrative = useMemo<StrategicNarrative>(() => ({
+            narrative_id: 'fallback',
+            user_id: userProfile?.user_id ?? '',
+            narrative_name: 'Interview Copilot Fallback',
+            desired_title: '',
+            positioning_statement: '',
+            impact_stories: [],
+        }), [userProfile?.user_id]);
+
+        if (isAppLoading || !app || !interview || !company) {
             return <div className="flex-1 flex items-center justify-center"><LoadingSpinner /></div>;
         }
-    
+
+        const narrativeForView = activeNarrative ?? fallbackNarrative;
+
         return (
             <InterviewCopilotView
                 application={app}
                 interview={interview}
                 company={company}
-                activeNarrative={activeNarrative}
+                activeNarrative={narrativeForView}
                 onBack={() => navigate(`/application/${app.job_application_id}?tab=interviews`)}
                 onSaveInterview={handleSaveInterview}
                 onGenerateInterviewPrep={handleGenerateInterviewPrep}

--- a/components/InterviewCopilotView.tsx
+++ b/components/InterviewCopilotView.tsx
@@ -31,7 +31,7 @@ interface InterviewCopilotViewProps {
     application: JobApplication;
     interview: Interview;
     company: Company;
-    activeNarrative: StrategicNarrative;
+    activeNarrative: StrategicNarrative | null;
     onBack: () => void;
     onSaveInterview: (payload: InterviewPayload, interviewId: string) => Promise<void>;
     onGenerateInterviewPrep: (app: JobApplication, interview: Interview) => Promise<void>;
@@ -225,6 +225,15 @@ const pruneCoverage = (values: string[], covered: string[]): string[] => {
     return covered.filter((value) => set.has(value));
 };
 
+const buildFallbackNarrative = (): StrategicNarrative => ({
+    narrative_id: 'fallback',
+    user_id: '',
+    narrative_name: 'Fallback Narrative',
+    desired_title: '',
+    positioning_statement: '',
+    impact_stories: [],
+});
+
 export const InterviewCopilotView = ({
     application,
     interview,
@@ -242,14 +251,19 @@ export const InterviewCopilotView = ({
     const [notesSuccess, setNotesSuccess] = useState(false);
     const [isGeneratingPrep, setIsGeneratingPrep] = useState(false);
 
+    const narrative = useMemo(
+        () => activeNarrative ?? buildFallbackNarrative(),
+        [activeNarrative],
+    );
+
     const jobAnalysis = useMemo(() => application.job_problem_analysis_result, [application]);
     const prepOutline = useMemo(
         () => buildPrepOutline(jobAnalysis, interview.prep_outline),
         [jobAnalysis, interview.prep_outline],
     );
     const storyDeck = useMemo(
-        () => buildHydratedDeck(interview, activeNarrative),
-        [interview, activeNarrative],
+        () => buildHydratedDeck(interview, narrative),
+        [interview, narrative],
     );
 
     const defaultLayouts = useMemo(() => buildDefaultLayouts(), []);
@@ -259,7 +273,7 @@ export const InterviewCopilotView = ({
         const context = {
             application,
             interview,
-            narrative: activeNarrative,
+            narrative,
             prepOutline,
             storyDeck,
             jobAnalysis,
@@ -299,7 +313,7 @@ export const InterviewCopilotView = ({
     }, [
         application,
         interview,
-        activeNarrative,
+        narrative,
         prepOutline,
         storyDeck,
         jobAnalysis,
@@ -441,10 +455,10 @@ export const InterviewCopilotView = ({
             jobAnalysis,
             interview,
             application,
-            narrative: activeNarrative,
-            availableStories: activeNarrative.impact_stories || [],
+            narrative,
+            availableStories: narrative.impact_stories || [],
         }),
-        [appendToNotes, jobAnalysis, interview, application, activeNarrative],
+        [appendToNotes, jobAnalysis, interview, application, narrative],
     );
 
     const handleSave = useCallback(async () => {
@@ -454,7 +468,7 @@ export const InterviewCopilotView = ({
             const context = {
                 application,
                 interview,
-                narrative: activeNarrative,
+                narrative,
                 prepOutline,
                 storyDeck,
                 jobAnalysis,
@@ -489,7 +503,7 @@ export const InterviewCopilotView = ({
     }, [
         application,
         interview,
-        activeNarrative,
+        narrative,
         prepOutline,
         storyDeck,
         jobAnalysis,

--- a/components/__tests__/InterviewCopilotView.test.tsx
+++ b/components/__tests__/InterviewCopilotView.test.tsx
@@ -69,13 +69,13 @@ const company: Company = {
 };
 
 describe('InterviewCopilotView', () => {
-    const renderView = () =>
+    const renderView = (narrative: StrategicNarrative | null = activeNarrative) =>
         render(
             <InterviewCopilotView
                 application={baseApplication}
                 interview={baseInterview}
                 company={company}
-                activeNarrative={activeNarrative}
+                activeNarrative={narrative}
                 onBack={() => undefined}
                 onSaveInterview={async () => undefined}
                 onGenerateInterviewPrep={async () => undefined}
@@ -89,6 +89,13 @@ describe('InterviewCopilotView', () => {
         expect(screen.getByText('Job Cheat Sheet')).toBeInTheDocument();
         expect(screen.getByText('Live Notes')).toBeInTheDocument();
         expect(screen.queryByText('Role Intelligence Research')).not.toBeInTheDocument();
+    });
+
+    it('renders with a missing narrative by falling back to defaults', () => {
+        renderView(null);
+
+        expect(screen.getByText('Job Cheat Sheet')).toBeInTheDocument();
+        expect(screen.getByText('Live Notes')).toBeInTheDocument();
     });
 
     it('switches to prep workspace when toggled', () => {

--- a/components/interview-copilot/componentRegistry.tsx
+++ b/components/interview-copilot/componentRegistry.tsx
@@ -80,16 +80,35 @@ const topOfMindInitialState = ({ interview }: WidgetInitContext): WidgetState<To
     },
 });
 
-const openingInitialState = ({ interview, narrative, application }: WidgetInitContext): WidgetState<StrategicOpeningData> => ({
-    id: 'strategicOpening',
-    data: {
-        opening:
-            interview.strategic_opening ||
-            `"I'm a product leader who excels at ${narrative.positioning_statement}. My understanding is the core challenge here is ${
-                application.job_problem_analysis_result?.core_problem_analysis?.core_problem || '...'
-            }. That's a problem I'm familiar with from my time when I ${narrative.impact_story_title}."`,
-    },
-});
+const openingInitialState = ({ interview, narrative, application }: WidgetInitContext): WidgetState<StrategicOpeningData> => {
+    const savedOpening = interview.strategic_opening?.trim();
+    if (savedOpening) {
+        return {
+            id: 'strategicOpening',
+            data: { opening: savedOpening },
+        };
+    }
+
+    const positioning = narrative.positioning_statement?.trim();
+    const coreProblem = application.job_problem_analysis_result?.core_problem_analysis?.core_problem?.trim();
+    const storyTitle = narrative.impact_story_title?.trim();
+
+    const intro = positioning
+        ? `"I'm a product leader who excels at ${positioning}."`
+        : '"I appreciate the chance to connect today."';
+    const problemStatement = coreProblem ? `My understanding is the core challenge here is ${coreProblem}.` : null;
+    const credibility = storyTitle ? `That's a problem I'm familiar with from my time when I ${storyTitle}.` : null;
+
+    const opening = [intro, problemStatement, credibility].filter(Boolean).join(' ');
+
+    return {
+        id: 'strategicOpening',
+        data: {
+            opening: opening ||
+                'Use this space to craft an opening that connects your background to their priorities.',
+        },
+    };
+};
 
 const questionsInitialState = ({ interview }: WidgetInitContext): WidgetState<QuestionArsenalData> => ({
     id: 'questionArsenal',

--- a/components/interview-copilot/widgets/ImpactStoriesWidget.tsx
+++ b/components/interview-copilot/widgets/ImpactStoriesWidget.tsx
@@ -105,6 +105,7 @@ export const ImpactStoriesWidget = ({
 }: WidgetProps<ImpactStoriesData>) => {
     const [draggingStoryId, setDraggingStoryId] = useState<string | null>(null);
     const availableStories = context.availableStories || [];
+    const hasAvailableStories = availableStories.length > 0;
 
     const availableRoles = useMemo(() => {
         const roles = new Set<string>(['default']);
@@ -212,7 +213,11 @@ export const ImpactStoriesWidget = ({
                         <ImpactStoryTrigger key={item.story_id} item={item} activeRole={data.activeRole} onNoteChange={handleNoteChange} isPrep={false} />
                     ))
                 ) : (
-                    <p className="text-sm text-slate-500 dark:text-slate-400">Add stories in prep mode to surface them here.</p>
+                    <p className="text-sm text-slate-500 dark:text-slate-400">
+                        {hasAvailableStories
+                            ? 'Add stories in prep mode to surface them here.'
+                            : 'No stories available yet. Add impact stories to your narrative to populate this section.'}
+                    </p>
                 )}
             </div>
             <p className="text-[11px] text-slate-500 dark:text-slate-400">Last updated: {formatTimestamp(lastUpdated)}</p>
@@ -272,6 +277,7 @@ export const ImpactStoriesWidget = ({
                 <select
                     value={data.storyToAdd}
                     onChange={(event) => onChange({ ...data, storyToAdd: event.target.value })}
+                    disabled={!hasAvailableStories}
                     className="w-full rounded-md border border-slate-300 bg-white px-2 py-1 text-xs shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-800"
                 >
                     <option value="">Select story to add</option>
@@ -284,12 +290,17 @@ export const ImpactStoriesWidget = ({
                 <button
                     type="button"
                     onClick={handleAddStory}
-                    disabled={!data.storyToAdd}
+                    disabled={!hasAvailableStories || !data.storyToAdd}
                     className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-400"
                 >
                     <SparklesIcon className="h-4 w-4" /> Add Story
                 </button>
             </div>
+            {!hasAvailableStories && (
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Add impact stories to your narrative in the Positioning Hub to enable this widget.
+                </p>
+            )}
             <div className="space-y-3">
                 {data.storyDeck.length > 0 ? (
                     data.storyDeck.map((item) => (


### PR DESCRIPTION
## Summary
- ensure the Interview Copilot route supplies a lightweight fallback narrative when the active narrative is unavailable
- guard narrative usage within the copilot view and widgets so missing positioning statements or stories render friendly guidance
- extend the InterviewCopilotView test suite to cover rendering with the fallback narrative

## Testing
- npm run test -- InterviewCopilotView *(fails: vitest not found in environment)*
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef7c7016188330aaf778cc67a8fa20